### PR TITLE
chore: added raw sequencing file Python script (#5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ _templates
 
 # favicons
 /public/favicons/*
+
+# unprocessed files
+/files/unprocessed_files/*

--- a/README.md
+++ b/README.md
@@ -30,3 +30,14 @@ yarn dev
 ```
 
 Once the server is running, visit [localhost:3000](localhost:3000) to view the Explorer!
+
+### Building the raw annotation data
+The raw annotation data is generated through a Python script. To install the required libraries
+use the following command from the root project directory:
+```shell
+pip install -r files/requirements.txt
+```
+Then run the script with:
+```shell
+python3 files/build-raw-sequencing-files.py
+```

--- a/files/build-raw-sequencing-files.py
+++ b/files/build-raw-sequencing-files.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 STORAGE_FOLDER_PATH = "./files/unprocessed_files/"
-OUTPUT_PATH = "./files/source/raw_sequencing_data.tsv"
+OUTPUT_PATH = "./files/source/raw-sequencing-data.tsv"
 DEEPCONSENSUS_URL = "https://raw.githubusercontent.com/human-pangenomics/HPRC_metadata/main/data/sample-files/hprc_metadata_sample_files_DEEPCONSENSUS.tsv"
 HIFI_URL = "https://raw.githubusercontent.com/human-pangenomics/HPRC_metadata/main/data/sample-files/hprc_metadata_sample_files_HiFi.tsv"
 ONT_URL = "https://raw.githubusercontent.com/human-pangenomics/HPRC_metadata/main/data/sample-files/hprc_metadata_sample_files_ONT.tsv"

--- a/files/build-raw-sequencing-files.py
+++ b/files/build-raw-sequencing-files.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 STORAGE_FOLDER_PATH = "./files/unprocessed_files/"
-OUTPUT_PATH = "./files/out/raw_sequencing_data.tsv"
+OUTPUT_PATH = "./files/source/raw_sequencing_data.tsv"
 DEEPCONSENSUS_URL = "https://raw.githubusercontent.com/human-pangenomics/HPRC_metadata/main/data/sample-files/hprc_metadata_sample_files_DEEPCONSENSUS.tsv"
 HIFI_URL = "https://raw.githubusercontent.com/human-pangenomics/HPRC_metadata/main/data/sample-files/hprc_metadata_sample_files_HiFi.tsv"
 ONT_URL = "https://raw.githubusercontent.com/human-pangenomics/HPRC_metadata/main/data/sample-files/hprc_metadata_sample_files_ONT.tsv"

--- a/files/build-raw-sequencing-files.py
+++ b/files/build-raw-sequencing-files.py
@@ -1,0 +1,57 @@
+import pandas as pd
+import numpy as np
+import requests
+from pathlib import Path
+from urllib.parse import urlparse
+
+STORAGE_FOLDER_PATH = "./files/unprocessed_files/"
+OUTPUT_PATH = "./files/out/raw_sequencing_data.tsv"
+DEEPCONSENSUS_URL = "https://raw.githubusercontent.com/human-pangenomics/HPRC_metadata/main/data/sample-files/hprc_metadata_sample_files_DEEPCONSENSUS.tsv"
+HIFI_URL = "https://raw.githubusercontent.com/human-pangenomics/HPRC_metadata/main/data/sample-files/hprc_metadata_sample_files_HiFi.tsv"
+ONT_URL = "https://raw.githubusercontent.com/human-pangenomics/HPRC_metadata/main/data/sample-files/hprc_metadata_sample_files_ONT.tsv"
+METADATA_URLS = [DEEPCONSENSUS_URL, HIFI_URL, ONT_URL]
+TABLE_URL = "https://raw.githubusercontent.com/human-pangenomics/HPRC_metadata/main/data/production/hprc-production-biosample-table.tsv"
+
+def downloadSourceFiles(urls, outputFolderPath):
+    paths = []
+    for url in urls:
+        # Get the filename and the path where the output will be saved
+        filename = Path(urlparse(url).path).name
+        outputPath = Path(outputFolderPath, filename)
+        # Download the text associated with each of the provided urls
+        with requests.get(url) as r:
+            if r.status_code != 200:
+                raise RuntimeError(f"{url} caused error {r.status_code}. See details below:\n {r.text}")
+            with open(outputPath.resolve(), "w") as f:
+                f.write(r.text)
+            paths.append(outputPath)
+    return paths
+
+def joinSamples(metadataPaths, tablePath):
+    # Generate each column across all provided sheets
+    metadataList = [pd.read_csv(path, sep="\t") for path in metadataPaths]
+    metadataColumns = np.unique([df.columns for df in metadataList])
+    # Concatenate all the provided metadata sheets
+    allMetadata = pd.concat(
+        metadataList,
+        axis=0,
+        ignore_index=True
+    ).reindex(columns=metadataColumns).fillna("N/A")
+    # Join the concatenated sheets with the table
+    table = pd.read_csv(tablePath, sep="\t")
+    joined = allMetadata.merge(
+        table,
+        left_on='sample_ID',
+        right_on='Sample',
+        how='left',
+        validate="many_to_one"
+    )
+    print("The following samples did not have corresponding metadata:")
+    print(", ".join(allMetadata[~allMetadata["sample_ID"].isin(table["Sample"])]["sample_ID"].unique()))
+    return joined
+
+if __name__ == "__main__":
+    metadataFiles = downloadSourceFiles(METADATA_URLS, STORAGE_FOLDER_PATH)
+    tableFile = downloadSourceFiles([TABLE_URL], STORAGE_FOLDER_PATH)[0]
+    joined = joinSamples(metadataFiles, tableFile)
+    joined.to_csv(OUTPUT_PATH, sep="\t", index=False)

--- a/files/build-raw-sequencing-files.py
+++ b/files/build-raw-sequencing-files.py
@@ -10,7 +10,7 @@ DEEPCONSENSUS_URL = "https://raw.githubusercontent.com/human-pangenomics/HPRC_me
 HIFI_URL = "https://raw.githubusercontent.com/human-pangenomics/HPRC_metadata/main/data/sample-files/hprc_metadata_sample_files_HiFi.tsv"
 ONT_URL = "https://raw.githubusercontent.com/human-pangenomics/HPRC_metadata/main/data/sample-files/hprc_metadata_sample_files_ONT.tsv"
 METADATA_URLS = [DEEPCONSENSUS_URL, HIFI_URL, ONT_URL]
-TABLE_URL = "https://raw.githubusercontent.com/human-pangenomics/HPRC_metadata/main/data/production/hprc-production-biosample-table.tsv"
+BIOSAMPLES_TABLE_URL = "https://raw.githubusercontent.com/human-pangenomics/HPRC_metadata/main/data/production/hprc-production-biosample-table.tsv"
 
 def downloadSourceFiles(urls, outputFolderPath):
     paths = []
@@ -27,7 +27,7 @@ def downloadSourceFiles(urls, outputFolderPath):
             paths.append(outputPath)
     return paths
 
-def joinSamples(metadataPaths, tablePath):
+def joinSamples(metadataPaths, biosamplesTablePath):
     # Generate each column across all provided sheets
     metadataList = [pd.read_csv(path, sep="\t") for path in metadataPaths]
     metadataColumns = np.unique([df.columns for df in metadataList])
@@ -38,20 +38,20 @@ def joinSamples(metadataPaths, tablePath):
         ignore_index=True
     ).reindex(columns=metadataColumns).fillna("N/A")
     # Join the concatenated sheets with the table
-    table = pd.read_csv(tablePath, sep="\t")
+    biosamplesTable = pd.read_csv(biosamplesTablePath, sep="\t")
     joined = allMetadata.merge(
-        table,
+        biosamplesTable,
         left_on='sample_ID',
         right_on='Sample',
         how='left',
         validate="many_to_one"
     )
-    print("The following samples did not have corresponding metadata:")
-    print(", ".join(allMetadata[~allMetadata["sample_ID"].isin(table["Sample"])]["sample_ID"].unique()))
+    print("The following biosamples did not have corresponding metadata:")
+    print(", ".join(allMetadata[~allMetadata["sample_ID"].isin(biosamplesTable["Sample"])]["sample_ID"].unique()))
     return joined
 
 if __name__ == "__main__":
     metadataFiles = downloadSourceFiles(METADATA_URLS, STORAGE_FOLDER_PATH)
-    tableFile = downloadSourceFiles([TABLE_URL], STORAGE_FOLDER_PATH)[0]
-    joined = joinSamples(metadataFiles, tableFile)
+    biosamplesTableFile = downloadSourceFiles([BIOSAMPLES_TABLE_URL], STORAGE_FOLDER_PATH)[0]
+    joined = joinSamples(metadataFiles, biosamplesTableFile)
     joined.to_csv(OUTPUT_PATH, sep="\t", index=False)

--- a/files/requirements.txt
+++ b/files/requirements.txt
@@ -1,0 +1,11 @@
+certifi==2024.7.4
+charset-normalizer==3.3.2
+idna==3.7
+numpy==2.0.1
+pandas==2.2.2
+python-dateutil==2.9.0.post0
+pytz==2024.1
+requests==2.32.3
+six==1.16.0
+tzdata==2024.1
+urllib3==2.2.2


### PR DESCRIPTION
Wrote a script to:
- Download the appropriate files from Github repositories
- Join and concatenate the files as instructed in (#5)
- Save the output file in `/files/out`
 checked to confirm that the concatenation worked properly, I would have added some sort of automatic check but it did not seem possible due to the simple nature of this script.

This script requires that the user has Python and Numpy installed in their active environment.