### PR TITLE
chore: added e2e tests that do not depend on filter or column names

### DIFF
--- a/e2e/hprc-filters.spec.ts
+++ b/e2e/hprc-filters.spec.ts
@@ -1,0 +1,55 @@
+import { test } from "@playwright/test";
+import { HPRC_TABS } from "./hprc-tabs";
+import {
+  testAllFiltersPresence,
+  testFirstNFilterCounts,
+} from "./testFunctions";
+
+test("Expect at least one filter to exist on the Raw Sequencing Data tab and for all filters to function", async ({
+  page,
+}) => {
+  await testAllFiltersPresence(page, HPRC_TABS.rawSequencingData);
+});
+
+test("Expect at least one filter to exist on the Assemblies tab and for all filters to function", async ({
+  page,
+}) => {
+  await testAllFiltersPresence(page, HPRC_TABS.assemblies);
+});
+
+test("Expect at least one filter to exist on the Pangenomes tab and for all filters to function", async ({
+  page,
+}) => {
+  await testAllFiltersPresence(page, HPRC_TABS.pangenomes);
+});
+
+test("Expect filter counts to update for the first five filters on the Raw Sequencing Data tab", async ({
+  page,
+}) => {
+  const result = await testFirstNFilterCounts(
+    page,
+    HPRC_TABS.rawSequencingData,
+    3
+  );
+  if (!result) {
+    test.fail();
+  }
+});
+
+test("Expect filter counts to update for the first five filters on the Assemblies tab", async ({
+  page,
+}) => {
+  const result = await testFirstNFilterCounts(page, HPRC_TABS.assemblies, 3);
+  if (!result) {
+    test.fail();
+  }
+});
+
+test("Expect filter counts to update for the first five on the Pangenomes tab", async ({
+  page,
+}) => {
+  const result = await testFirstNFilterCounts(page, HPRC_TABS.pangenomes, 3);
+  if (!result) {
+    test.fail();
+  }
+});

--- a/e2e/hprc-sort.spec.ts
+++ b/e2e/hprc-sort.spec.ts
@@ -1,0 +1,21 @@
+import { test } from "@playwright/test";
+import { HPRC_TABS } from "./hprc-tabs";
+import { testSortFirstColumn } from "./testFunctions";
+
+test("Expect sorting the first column of the Raw Sequencing Data tab to switch its first and last entry", async ({
+  page,
+}) => {
+  await testSortFirstColumn(page, HPRC_TABS.rawSequencingData);
+});
+
+test("Expect sorting the first column of the Assemblies tab to switch its first and last entry", async ({
+  page,
+}) => {
+  await testSortFirstColumn(page, HPRC_TABS.assemblies);
+});
+
+test("Expect sorting the first column of the Pangenomes tab to switch its first and last entry", async ({
+  page,
+}) => {
+  await testSortFirstColumn(page, HPRC_TABS.pangenomes);
+});

--- a/e2e/hprc-table.spec.ts
+++ b/e2e/hprc-table.spec.ts
@@ -1,0 +1,21 @@
+import { test } from "@playwright/test";
+import { HPRC_TABS } from "./hprc-tabs";
+import { testTableExists } from "./testFunctions";
+
+test("Expect the table to exist and have at least one row on the Raw Sequencing Data tab", async ({
+  page,
+}) => {
+  await testTableExists(page, HPRC_TABS.rawSequencingData);
+});
+
+test("Expect the table to exist and have at least one row on the Assemblies tab", async ({
+  page,
+}) => {
+  await testTableExists(page, HPRC_TABS.assemblies);
+});
+
+test("Expect the table to exist and have at least one row on the Pangenomes tab", async ({
+  page,
+}) => {
+  await testTableExists(page, HPRC_TABS.pangenomes);
+});

--- a/e2e/hprc-tabs.ts
+++ b/e2e/hprc-tabs.ts
@@ -1,0 +1,28 @@
+import { HprcTabCollection } from "./testInterfaces";
+
+export const HPRC_TABS: HprcTabCollection = {
+  assemblies: {
+    preselectedColumns: [],
+    selectableColumns: [],
+    tabName: "Assemblies",
+    url: "/assemblies",
+  },
+  pangenomes: {
+    preselectedColumns: [],
+    selectableColumns: [],
+    tabName: "Pangenomes",
+    url: "/pangenomes",
+  },
+  rawSequencingData: {
+    preselectedColumns: [],
+    selectableColumns: [],
+    tabName: "Raw Sequencing Data",
+    url: "/raw-sequencing-data",
+  },
+};
+
+export const HPRC_TAB_LIST = [
+  HPRC_TABS.rawSequencingData,
+  HPRC_TABS.assemblies,
+  HPRC_TABS.pangenomes,
+];

--- a/e2e/hprc-urls.spec.ts
+++ b/e2e/hprc-urls.spec.ts
@@ -1,0 +1,24 @@
+import { test } from "@playwright/test";
+import { HPRC_TABS, HPRC_TAB_LIST } from "./hprc-tabs";
+import { testUrl } from "./testFunctions";
+
+test("Expect the Raw Sequencing Data tab to appear as selected when the corresponding url is accessed", async ({
+  page,
+}) => {
+  const tab = HPRC_TABS.rawSequencingData;
+  await testUrl(page, tab, HPRC_TAB_LIST);
+});
+
+test("Expect the Assemblies tab to appear as selected when the corresponding url is accessed", async ({
+  page,
+}) => {
+  const tab = HPRC_TABS.assemblies;
+  await testUrl(page, tab, HPRC_TAB_LIST);
+});
+
+test("Expect the Pangenomes tab to appear as selected when the corresponding url is accessed", async ({
+  page,
+}) => {
+  const tab = HPRC_TABS.pangenomes;
+  await testUrl(page, tab, HPRC_TAB_LIST);
+});

--- a/e2e/test-readme.md
+++ b/e2e/test-readme.md
@@ -1,0 +1,58 @@
+## HPRC Data Explorer End-To-End Tests
+
+### Test Information
+
+All tests are stored in `/explorer/e2e`. Playwright will run tests in any file with the suffix `*.spec.ts`, so long as these files are stored in `/explorer/e2e`.
+Tests for a specific configuration are stored as `config_name/config_name-test_name.spec.ts`. While these are the tests
+that Playwright actually runs, most test code is stored in `e2e/testFunctions.ts`. These functions contain the
+code that runs for all tests, except for tests that are not reused between configurations and that only run in one tab. This allows tests to be repeated
+for different tabs in different configurations without reusing code, and means that information that tests
+depend on can be stored in one place to make adjusting tests to changes in user-facing content is straightforward.
+Config specific constants used for tests are kept in the `hprc-tabs.ts`, and use interfaces and
+custom types in `testInterfaces.ts`.
+
+### Running Tests
+
+#### Running Locally
+
+To run all tests locally, run `npm run test:e2e`. If there is no server running
+on `localhost:3000`, this will create a dev build of the correct configuration and run the tests on Chromium, Firefox, and Webkit (Safari). The tests may be flaky
+if run on the `dev` version instead of a dev build, as the site will run too slow and they may time out. Traces
+and screenshots from any tests that fail will be output to `explorer/playwright-report`. To manually run an individual test file,
+run `npx playwright test e2efilename.spec.ts`. To run an individual test, add the argument `-g <test_name>`. More information
+about command line options for the test can be found in [Playwright's Documentation](https://playwright.dev/docs/test-cli).
+To debug or write tests, it can be useful to use Playwright's UI mode with `npx playwright test --ui`, which allows you
+to easily run individual tests, and view the actions Playwright takes step by step and their result.
+
+#### Running in GitHub
+
+All tests are run automatically when a pull request is made, using GitHub Actions. These actions create a dev build
+for each configuration, then run the test. When a test passes, it will become visible on GitHub. If one fails, screenshots
+and traces can be downloaded from GitHub. To view step by step what happened in the test, visit `trace.playwright.dev`
+in a web browser and upload the `trace.zip` file. This web app, which runs entirely in browser, allows you to step
+through the actions taken as part of the test and view the impact on the web page.
+
+### Current Tests
+
+- Filters (`hprc-filters.spec.ts`)
+  - Check that all text that matches a filter regex is clickable, shows a filter menu with checkboxes when clicked, and that the filter menu disapperas when the center of the page is clicked
+    - Uses the regex "^(.+)\s+\([0-9]+\)\s\*" to match all filter buttons
+    - Once the list of filters is finalized, this should be converted to using a constant list of filters
+    - Runs on all three tabs
+  - Check that the filter counts in the filter menus match the resulting row counts for the main table for the first three filters on each tab
+    - Once the list of filters is finalized, this should be converted to using a constant list of filters
+- Sort (`hprc-sort.spec.ts`)
+  - Check that clicking the table header of the first row switches the first and last rows in that row
+    - Does not check that any actual sorting occurs, only that the first and last rows are switched
+    - Runs on all three tables
+    - Should be expanded to run on all sortable columns once column names are finalized
+- Navigation
+  - Check that all tabs appear on each tab page
+    - Runs on all tabs
+    - Cannot tell what tabs are selected because the aria-selected value is not set for the tab buttons
+    - `hprc-urls.spec.ts`
+  - Check that the data table appears on each tab and that the first cell of the first column is visible
+    - Runs on all tabs
+    - `hprc-table.spec.ts`
+  - Check that `/` redirects to `/raw-sequencing-data` (`smoke-test.spec.ts`)
+- All tests rely on correct lists of tabs in `hprc-tabs.ts`

--- a/e2e/testFunctions.ts
+++ b/e2e/testFunctions.ts
@@ -1,0 +1,333 @@
+import { expect, Locator, Page } from "@playwright/test";
+import { TabDescription } from "./testInterfaces";
+
+/**
+ * Tests that the tab url goes to a valid page and that the correct tab (and only
+ * the correct tab) appears selected
+ * @param page - a Playwright page object
+ * @param tab - the Tab object to check
+ * @param otherTabs - an array of the other Tab objects for this configuration
+ */
+export async function testUrl(
+  page: Page,
+  tab: TabDescription,
+  otherTabs: TabDescription[]
+): Promise<void> {
+  await page.goto(tab.url);
+  // Currently, there is no non-flaky way to use Playwright to determine if a tab is selected,
+  // so this test just checks for visibility.
+  await expect(
+    page.getByRole("button").getByText(tab.tabName, { exact: true })
+  ).toBeVisible();
+  for (const otherTab of otherTabs) {
+    if (otherTab.tabName !== tab.tabName) {
+      await expect(
+        page.getByRole("button").getByText(otherTab.tabName)
+      ).toBeVisible();
+    }
+  }
+}
+
+/**
+ * Test that the main table is visible and has at least one cell
+ * @param page - a Playwright page object
+ * @param tab - the tab object to test on
+ */
+export async function testTableExists(
+  page: Page,
+  tab: TabDescription
+): Promise<void> {
+  await page.goto(tab.url);
+  await expect(page.getByRole("table")).toBeVisible();
+  await expect(
+    page.getByRole("rowgroup").nth(1).getByRole("cell").first()
+  ).toBeVisible();
+}
+
+/**
+ * Returns a regex that matches the sidebar filter buttons
+ * This is useful for selecting a filter from the sidebar
+ * @param filterName - the name of the filter to match
+ * @returns a regular expression matching "[filterName] ([n])"
+ */
+export const filterRegex = (filterName: string): RegExp =>
+  new RegExp("^(" + filterName + ")" + "\\s+\\([0-9]+\\)\\s*");
+
+/**
+ * Get an array of all filter names on the current page
+ * @param page - a Playwright Page object
+ * @returns - an array of filter names
+ */
+const getAllFilterNames = async (page: Page): Promise<string[]> => {
+  await expect(page.getByText(filterRegex(".+")).first()).toBeVisible();
+  const allFilterRegex = filterRegex(".+");
+  /*await expect(page.getByText(allFilterRegex).first()).toContainText(
+    /\(([0-9])+\)/
+  );*/
+  const filterStrings = await page.getByText(filterRegex(".+")).allInnerTexts();
+  return filterStrings.map(
+    (x: string) => (x.match(allFilterRegex) ?? ["", ""])[1]
+  );
+};
+
+/**
+ * Test that all text that looks like a filter button is clickable and opens
+ * a filter menu with at least one checkbox.
+ * This is a temporary test to be used until a permanent list of filter names
+ * is found.
+ * @param page - a Playwright page object
+ * @param tab - the tab object to test on
+ */
+export async function testAllFiltersPresence(
+  page: Page,
+  tab: TabDescription
+): Promise<void> {
+  // Temp test to be used until we have a stable list of filters
+  await page.goto(tab.url);
+  const filterNames = await getAllFilterNames(page);
+  await testFilterPresence(page, tab, filterNames);
+}
+
+/**
+ * Checks that each filter specified in filterNames is visible and can be
+ * selected on the specified tab
+ * @param page - a Playwright page object
+ * @param tab - the tab to check
+ * @param filterNames - the names of the filters who whose existence should be tested for
+ */
+export async function testFilterPresence(
+  page: Page,
+  tab: TabDescription,
+  filterNames: string[]
+): Promise<void> {
+  // Goto the selected tab
+  await page.goto(tab.url);
+  await expect(page.getByRole("button").getByText(tab.tabName)).toBeVisible();
+  for (const filter of filterNames) {
+    // Check that each filter is visible and clickable
+    await expect(page.getByText(filterRegex(filter))).toBeVisible();
+    await page.getByText(filterRegex(filter)).dispatchEvent("click");
+    await expect(page.getByRole("checkbox").first()).toBeVisible();
+    await expect(page.getByRole("checkbox").first()).not.toBeChecked();
+    // Check that clicking out of the filter menu causes it to disappear
+    await page.locator("body").click();
+    await expect(page.getByRole("checkbox")).toHaveCount(0);
+  }
+}
+
+/**
+ * Get a locator for a filter option with name filterName
+ * @param page - a Playwright page object
+ * @param filterName - the filterName to search for
+ * @returns - a Playwright locator object for the filter option
+ */
+export const getNamedFilterButtonLocator = (
+  page: Page,
+  filterName: string
+): Locator => {
+  return page
+    .getByRole("button")
+    .filter({ has: page.getByRole("checkbox"), hasText: filterName });
+};
+
+/**
+ * Get a locator for the first filter option on the page.
+ * @param page - a Playwright page object
+ * @returns - a Playwright locator object for the first filter option on the page
+ */
+export const getFirstFilterButtonLocator = (page: Page): Locator => {
+  return page
+    .getByRole("button")
+    .filter({ has: page.getByRole("checkbox") })
+    .first();
+};
+
+/**
+ * Test that Filter counts update correctly for the first n filters on the page.
+ * This is a temporary test that should only be used until a final list of
+ * filters is available.
+ * @param page - a Playwright page object
+ * @param tab - the tab object to run the test on
+ * @param n - the number of filters tot est
+ * @returns - true if the test passes and false if the test should fail
+ */
+export async function testFirstNFilterCounts(
+  page: Page,
+  tab: TabDescription,
+  n: number
+): Promise<boolean> {
+  await page.goto(tab.url);
+  const allFilterNames = await getAllFilterNames(page);
+  if (allFilterNames.length < n) {
+    console.log(
+      `There are only ${allFilterNames.length} filters, which is fewer than the ${n} specified for this test`
+    );
+    return false;
+  }
+  const firstNFilterNames = allFilterNames.slice(0, n);
+  return await testFilterCounts(page, tab, firstNFilterNames);
+}
+
+/**
+ * Test that the counts associated with an array of filter names are reflected
+ * in the table
+ * @param page - a Playwright page object
+ * @param tab - the tab object to test
+ * @param filterNames - the names of the filters to select, in order
+ * @returns false if the test should fail and true if the test should pass
+ */
+export async function testFilterCounts(
+  page: Page,
+  tab: TabDescription,
+  filterNames: string[]
+): Promise<boolean> {
+  await page.goto(tab.url);
+  const elementsPerPageRegex = /^Results 1 - ([0-9]+) of [0-9]+/;
+  await expect(page.getByText(elementsPerPageRegex)).toBeVisible();
+  const elementsPerPageText = ((
+    await page.getByText(elementsPerPageRegex).innerText()
+  ).match(elementsPerPageRegex) ?? ["", "-1"])[1];
+  const elementsPerPage = parseInt(elementsPerPageText) ?? -1;
+  if (elementsPerPage < 0) {
+    console.log(
+      "The number of elements per page was negative or did not appear"
+    );
+    return false;
+  }
+  // For each arbitrarily selected filter
+  for (const filter of filterNames) {
+    // Select the filter
+    await page.getByText(filterRegex(filter)).dispatchEvent("click");
+    // Get the number associated with the first filter button, and select it
+    await page.waitForLoadState("load");
+    const filterButton = getFirstFilterButtonLocator(page);
+    const filterNumbers = (await filterButton.innerText()).split("\n");
+    const filterNumber =
+      filterNumbers.map((x) => Number(x)).find((x) => !isNaN(x) && x !== 0) ??
+      -1;
+    if (filterNumber < 0) {
+      console.log(filterNumbers.map((x) => Number(x)));
+      return false;
+    }
+    // Check the filter
+    await filterButton.getByRole("checkbox").dispatchEvent("click");
+    await page.waitForLoadState("load");
+    // Exit the filter menu
+    await page.locator("body").click();
+    await expect(page.getByRole("checkbox")).toHaveCount(0);
+    // Expect the displayed count of elements to be 0
+    const firstNumber =
+      filterNumber <= elementsPerPage ? filterNumber : elementsPerPage;
+    await expect(
+      page.getByText("Results 1 - " + firstNumber + " of " + filterNumber)
+    ).toBeVisible();
+  }
+  return true;
+}
+
+/**
+ * Get a locator to the cell in the first row's nth column
+ * @param page - a Playwright page object
+ * @param columnIndex - the zero-indexed column to return
+ * @returns a Playwright locator object to the selected cell
+ **/
+export const getFirstRowNthColumnCellLocator = (
+  page: Page,
+  columnIndex: number
+): Locator => {
+  return page
+    .getByRole("rowgroup")
+    .nth(1)
+    .getByRole("row")
+    .nth(0)
+    .getByRole("cell")
+    .nth(columnIndex);
+};
+
+/**
+ * Get a locator to the cell in the last row's nth column
+ * @param page - a Playwright page object
+ * @param columnIndex - the zero-indexed column to return
+ * @returns a Playwright locator object to the selected cell
+ **/
+export const getLastRowNthColumnCellLocator = (
+  page: Page,
+  columnIndex: number
+): Locator => {
+  return page
+    .getByRole("rowgroup")
+    .nth(1)
+    .getByRole("row")
+    .last()
+    .getByRole("cell")
+    .nth(columnIndex);
+};
+
+/**
+ * Cause the current page to scroll to the top
+ * @param page - a Playwright page object
+ */
+const scrollToTop = async (page: Page): Promise<void> => {
+  await page.evaluate(() => {
+    window.scrollTo(0, 0);
+  });
+};
+
+/**
+ * Cause the current page to scroll to the bottom
+ * @param page - a Playwright page object
+ */
+const scrollToBottom = async (page: Page): Promise<void> => {
+  const scrollHeight = await page.evaluate(
+    () => window.document.documentElement.scrollHeight
+  );
+  await page.evaluate((height) => {
+    window.scrollTo(0, height);
+  }, scrollHeight);
+};
+
+/**
+ * Checks that sorting the tab by the first visible column  does not cause the
+ * first row of the table to break.
+ * This test does not check whether the sort order is correct.
+ * @param page - a Playwright page object
+ * @param tab - the tab to check
+ */
+export async function testSortFirstColumn(
+  page: Page,
+  tab: TabDescription
+): Promise<void> {
+  // Get the current tab, and go to it's URL
+  await page.goto(tab.url);
+  await expect(page.getByText(filterRegex(".+")).first()).toBeVisible();
+  const columnSortLocator = page
+    .getByRole("table")
+    .getByRole("columnheader")
+    .first()
+    .getByRole("button");
+  // Check that the first and last cells are visible
+  const firstElementTextLocator = getFirstRowNthColumnCellLocator(page, 0);
+  const lastElementTextLocator = getLastRowNthColumnCellLocator(page, 0);
+  await expect(firstElementTextLocator).toBeVisible();
+  await scrollToBottom(page);
+  await expect(lastElementTextLocator).toBeVisible();
+  await scrollToTop(page);
+  // Click to sort
+  await columnSortLocator.click();
+  // Expect the first cell to still be visible
+  await expect(firstElementTextLocator).toBeVisible();
+  const firstElementText = await firstElementTextLocator.innerText();
+  await scrollToBottom(page);
+  // Expect the last cell to still be visible
+  await expect(lastElementTextLocator).toBeVisible();
+  const lastElementText = await lastElementTextLocator.innerText();
+  await scrollToTop(page);
+  // Click to sort again
+  await columnSortLocator.click();
+  // Expect the first and last cell to have switched their text
+  await expect(firstElementTextLocator).toBeVisible();
+  await expect(firstElementTextLocator).toHaveText(lastElementText);
+  await scrollToBottom(page);
+  await expect(lastElementTextLocator).toBeVisible();
+  await expect(lastElementTextLocator).toHaveText(firstElementText);
+}

--- a/e2e/testFunctions.ts
+++ b/e2e/testFunctions.ts
@@ -103,10 +103,10 @@ export async function testFilterPresence(
   // Goto the selected tab
   await page.goto(tab.url);
   await expect(page.getByRole("button").getByText(tab.tabName)).toBeVisible();
-  for (const filter of filterNames) {
+  for (const filterName of filterNames) {
     // Check that each filter is visible and clickable
-    await expect(page.getByText(filterRegex(filter))).toBeVisible();
-    await page.getByText(filterRegex(filter)).dispatchEvent("click");
+    await expect(page.getByText(filterRegex(filterName))).toBeVisible();
+    await page.getByText(filterRegex(filterName)).dispatchEvent("click");
     await expect(page.getByRole("checkbox").first()).toBeVisible();
     await expect(page.getByRole("checkbox").first()).not.toBeChecked();
     // Check that clicking out of the filter menu causes it to disappear
@@ -195,9 +195,9 @@ export async function testFilterCounts(
     return false;
   }
   // For each arbitrarily selected filter
-  for (const filter of filterNames) {
+  for (const filterName of filterNames) {
     // Select the filter
-    await page.getByText(filterRegex(filter)).dispatchEvent("click");
+    await page.getByText(filterRegex(filterName)).dispatchEvent("click");
     // Get the number associated with the first filter button, and select it
     await page.waitForLoadState("load");
     const filterButton = getFirstFilterButtonLocator(page);
@@ -319,6 +319,9 @@ export async function testSortFirstColumn(
   const firstElementText = await firstElementTextLocator.innerText();
   await scrollToBottom(page);
   // Expect the last cell to still be visible
+  await expect(
+    page.getByRole("rowgroup").nth(1).getByRole("row").last()
+  ).not.toHaveText("");
   await expect(lastElementTextLocator).toBeVisible();
   const lastElementText = await lastElementTextLocator.innerText();
   await scrollToTop(page);

--- a/e2e/testFunctions.ts
+++ b/e2e/testFunctions.ts
@@ -45,26 +45,34 @@ export async function testTableExists(
 }
 
 /**
+ * Returns a string with special characters escaped
+ * @param string - the string to escape
+ * @returns - a string with special characters escaped
+ */
+export function escapeRegExp(string: string): string {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+/**
  * Returns a regex that matches the sidebar filter buttons
  * This is useful for selecting a filter from the sidebar
  * @param filterName - the name of the filter to match
  * @returns a regular expression matching "[filterName] ([n])"
  */
 export const filterRegex = (filterName: string): RegExp =>
-  new RegExp("^(" + filterName + ")" + "\\s+\\([0-9]+\\)\\s*");
+  new RegExp("^(" + escapeRegExp(filterName) + ")" + "\\s+\\([0-9]+\\)\\s*");
 
+const allFilterRegex = /^(.+)\s+\([0-9]+\)\s*/;
 /**
  * Get an array of all filter names on the current page
  * @param page - a Playwright Page object
  * @returns - an array of filter names
  */
 const getAllFilterNames = async (page: Page): Promise<string[]> => {
-  await expect(page.getByText(filterRegex(".+")).first()).toBeVisible();
-  const allFilterRegex = filterRegex(".+");
+  await expect(page.getByText(allFilterRegex).first()).toBeVisible();
   /*await expect(page.getByText(allFilterRegex).first()).toContainText(
     /\(([0-9])+\)/
   );*/
-  const filterStrings = await page.getByText(filterRegex(".+")).allInnerTexts();
+  const filterStrings = await page.getByText(allFilterRegex).allInnerTexts();
   return filterStrings.map(
     (x: string) => (x.match(allFilterRegex) ?? ["", ""])[1]
   );
@@ -299,7 +307,7 @@ export async function testSortFirstColumn(
 ): Promise<void> {
   // Get the current tab, and go to it's URL
   await page.goto(tab.url);
-  await expect(page.getByText(filterRegex(".+")).first()).toBeVisible();
+  await expect(page.getByText(allFilterRegex).first()).toBeVisible();
   const columnSortLocator = page
     .getByRole("table")
     .getByRole("columnheader")

--- a/e2e/testInterfaces.ts
+++ b/e2e/testInterfaces.ts
@@ -1,0 +1,17 @@
+export interface TabDescription {
+  preselectedColumns: columnDescription[];
+  selectableColumns: columnDescription[];
+  tabName: string;
+  url: string;
+}
+
+export interface HprcTabCollection {
+  assemblies: TabDescription;
+  pangenomes: TabDescription;
+  rawSequencingData: TabDescription;
+}
+
+export interface columnDescription {
+  name: string;
+  sortable: boolean;
+}


### PR DESCRIPTION
### Changes

Added the following tests. Some of them will need to be changed once the list of columns and filters become stable.
Also added descriptions for this test in `e2e/test-readme.md`

- Filters (`hprc-filters.spec.ts`)
  - Check that all text that matches a filter regex is clickable, shows a filter menu with checkboxes when clicked, and that the filter menu disapperas when the center of the page is clicked
    - Uses the regex "^(.+)\s+\([0-9]+\)\s\*" to match all filter buttons
    - Once the list of filters is finalized, this should be converted to using a constant list of filters
    - Runs on all three tabs
  - Check that the filter counts in the filter menus match the resulting row counts for the main table for the first three filters on each tab
    - Once the list of filters is finalized, this should be converted to using a constant list of filters
- Sort (`hprc-sort.spec.ts`)
  - Check that clicking the table header of the first row switches the first and last rows in that row
    - Does not check that any actual sorting occurs, only that the first and last rows are switched
    - Runs on all three tables
    - Should be expanded to run on all sortable columns once column names are finalized
- Navigation
  - Check that all tabs appear on each tab page
    - Runs on all tabs
    - Cannot tell what tabs are selected because the aria-selected value is not set for the tab buttons
    - `hprc-urls.spec.ts`
  - Check that the data table appears on each tab and that the first cell of the first column is visible
    - Runs on all tabs
    - `hprc-table.spec.ts`
  - Check that `/` redirects to `/raw-sequencing-data` (`smoke-test.spec.ts`)
- All tests rely on correct lists of tabs in `hprc-tabs.ts`

### Known Issues

- The `hprc- urls.spec.ts` tests do not check what tab is selected, as they do on the AnVIL tests. This is because the buttons used on this explorer do not change the ARIA-Selected value or any other value when they are selected, so there is no way to test this using Playwright.
- The `build-hprc-db` scripts are not run for these tests since the libraries are included on the Git repo. This can be changed if necessary.

