### PR TITLE
test: added search filters tests (#35)

### DIFF
--- a/e2e/hprc-filters.spec.ts
+++ b/e2e/hprc-filters.spec.ts
@@ -2,7 +2,9 @@ import { test } from "@playwright/test";
 import { HPRC_TABS } from "./hprc-tabs";
 import {
   testAllFiltersPresence,
+  testDeselectFiltersThroughSearchBarForFirstNFilters,
   testFirstNFilterCounts,
+  testSelectFiltersThroughSearchBarForFirstNFilters,
 } from "./testFunctions";
 
 test("Expect at least one filter to exist on the Raw Sequencing Data tab and for all filters to function", async ({
@@ -52,4 +54,92 @@ test("Expect filter counts to update for the first five on the Alignments tab", 
   if (!result) {
     test.fail();
   }
+});
+
+test('Check that selecting the first 3 filters through the "Search all Filters" textbox works correctly on the Raw Sequencing Data tab', async ({
+  page,
+}) => {
+  test.setTimeout(120000);
+  await testSelectFiltersThroughSearchBarForFirstNFilters(
+    page,
+    HPRC_TABS.rawSequencingData,
+    3
+  );
+});
+
+test('Check that selecting the first 3 filters through the "Search all Filters" textbox works correctly on the Assemblies tab', async ({
+  page,
+}) => {
+  test.setTimeout(120000);
+  await testSelectFiltersThroughSearchBarForFirstNFilters(
+    page,
+    HPRC_TABS.assemblies,
+    3
+  );
+});
+
+test('Check that selecting the first 3 filters through the "Search all Filters" textbox works correctly on the Annotations tab', async ({
+  page,
+}) => {
+  test.setTimeout(120000);
+  await testSelectFiltersThroughSearchBarForFirstNFilters(
+    page,
+    HPRC_TABS.annotations,
+    3
+  );
+});
+
+test('Check that selecting the first 3 filters through the "Search all Filters" textbox works correctly on the Alignments tab', async ({
+  page,
+}) => {
+  test.setTimeout(120000);
+  await testSelectFiltersThroughSearchBarForFirstNFilters(
+    page,
+    HPRC_TABS.alignments,
+    3
+  );
+});
+
+test('Check that deselecting the first 3 filters through the "Search all Filters" textbox works correctly on the Raw Sequencing Data tab', async ({
+  page,
+}) => {
+  test.setTimeout(120000);
+  await testDeselectFiltersThroughSearchBarForFirstNFilters(
+    page,
+    HPRC_TABS.rawSequencingData,
+    3
+  );
+});
+
+test('Check that deselecting the first 3 filters through the "Search all Filters" textbox works correctly on the Assemblies tab', async ({
+  page,
+}) => {
+  test.setTimeout(120000);
+  await testDeselectFiltersThroughSearchBarForFirstNFilters(
+    page,
+    HPRC_TABS.assemblies,
+    3
+  );
+});
+
+test('Check that deselecting the first 3 filters through the "Search all Filters" textbox works correctly on the Annotations tab', async ({
+  page,
+}) => {
+  test.setTimeout(120000);
+  await testDeselectFiltersThroughSearchBarForFirstNFilters(
+    page,
+    HPRC_TABS.annotations,
+    3
+  );
+});
+
+test('Check that deselecting the first 3 filters through the "Search all Filters" textbox works correctly on the Alignments tab', async ({
+  page,
+}) => {
+  test.setTimeout(120000);
+  await testDeselectFiltersThroughSearchBarForFirstNFilters(
+    page,
+    HPRC_TABS.alignments,
+    3
+  );
 });

--- a/e2e/hprc-filters.spec.ts
+++ b/e2e/hprc-filters.spec.ts
@@ -2,9 +2,8 @@ import { test } from "@playwright/test";
 import { HPRC_TABS } from "./hprc-tabs";
 import {
   testAllFiltersPresence,
-  testDeselectFiltersThroughSearchBarForFirstNFilters,
   testFirstNFilterCounts,
-  testSelectFiltersThroughSearchBarForFirstNFilters,
+  testSelectFiltersThroughSearchBar,
 } from "./testFunctions";
 
 test("Expect at least one filter to exist on the Raw Sequencing Data tab and for all filters to function", async ({
@@ -56,90 +55,26 @@ test("Expect filter counts to update for the first five on the Alignments tab", 
   }
 });
 
-test('Check that selecting the first 3 filters through the "Search all Filters" textbox works correctly on the Raw Sequencing Data tab', async ({
+test('Check that selecting the first filter through the "Search all Filters" textbox works correctly on the Raw Sequencing Data tab', async ({
   page,
 }) => {
-  test.setTimeout(120000);
-  await testSelectFiltersThroughSearchBarForFirstNFilters(
-    page,
-    HPRC_TABS.rawSequencingData,
-    3
-  );
+  await testSelectFiltersThroughSearchBar(page, HPRC_TABS.rawSequencingData);
 });
 
-test('Check that selecting the first 3 filters through the "Search all Filters" textbox works correctly on the Assemblies tab', async ({
+test('Check that selecting the first filter through the "Search all Filters" textbox works correctly on the Assemblies tab', async ({
   page,
 }) => {
-  test.setTimeout(120000);
-  await testSelectFiltersThroughSearchBarForFirstNFilters(
-    page,
-    HPRC_TABS.assemblies,
-    3
-  );
+  await testSelectFiltersThroughSearchBar(page, HPRC_TABS.assemblies);
 });
 
-test('Check that selecting the first 3 filters through the "Search all Filters" textbox works correctly on the Annotations tab', async ({
+test('Check that selecting the first filter through the "Search all Filters" textbox works correctly on the Annotations tab', async ({
   page,
 }) => {
-  test.setTimeout(120000);
-  await testSelectFiltersThroughSearchBarForFirstNFilters(
-    page,
-    HPRC_TABS.annotations,
-    3
-  );
+  await testSelectFiltersThroughSearchBar(page, HPRC_TABS.annotations);
 });
 
-test('Check that selecting the first 3 filters through the "Search all Filters" textbox works correctly on the Alignments tab', async ({
+test('Check that selecting the first filter through the "Search all Filters" textbox works correctly on the Alignments tab', async ({
   page,
 }) => {
-  test.setTimeout(120000);
-  await testSelectFiltersThroughSearchBarForFirstNFilters(
-    page,
-    HPRC_TABS.alignments,
-    3
-  );
-});
-
-test('Check that deselecting the first 3 filters through the "Search all Filters" textbox works correctly on the Raw Sequencing Data tab', async ({
-  page,
-}) => {
-  test.setTimeout(120000);
-  await testDeselectFiltersThroughSearchBarForFirstNFilters(
-    page,
-    HPRC_TABS.rawSequencingData,
-    3
-  );
-});
-
-test('Check that deselecting the first 3 filters through the "Search all Filters" textbox works correctly on the Assemblies tab', async ({
-  page,
-}) => {
-  test.setTimeout(120000);
-  await testDeselectFiltersThroughSearchBarForFirstNFilters(
-    page,
-    HPRC_TABS.assemblies,
-    3
-  );
-});
-
-test('Check that deselecting the first 3 filters through the "Search all Filters" textbox works correctly on the Annotations tab', async ({
-  page,
-}) => {
-  test.setTimeout(120000);
-  await testDeselectFiltersThroughSearchBarForFirstNFilters(
-    page,
-    HPRC_TABS.annotations,
-    3
-  );
-});
-
-test('Check that deselecting the first 3 filters through the "Search all Filters" textbox works correctly on the Alignments tab', async ({
-  page,
-}) => {
-  test.setTimeout(120000);
-  await testDeselectFiltersThroughSearchBarForFirstNFilters(
-    page,
-    HPRC_TABS.alignments,
-    3
-  );
+  await testSelectFiltersThroughSearchBar(page, HPRC_TABS.alignments);
 });

--- a/e2e/hprc-tabs.ts
+++ b/e2e/hprc-tabs.ts
@@ -1,20 +1,32 @@
 import { HprcTabCollection } from "./testInterfaces";
 
+const SEARCH_FILTERS_PLACEHOLDER_TEXT = "Search all filters...";
+
 export const HPRC_TABS: HprcTabCollection = {
   alignments: {
     preselectedColumns: [],
+    searchFiltersPlaceholderText: SEARCH_FILTERS_PLACEHOLDER_TEXT,
     selectableColumns: [],
     tabName: "Alignments",
     url: "/alignments",
   },
+  annotations: {
+    preselectedColumns: [],
+    searchFiltersPlaceholderText: SEARCH_FILTERS_PLACEHOLDER_TEXT,
+    selectableColumns: [],
+    tabName: "Annotations",
+    url: "/annotations",
+  },
   assemblies: {
     preselectedColumns: [],
+    searchFiltersPlaceholderText: SEARCH_FILTERS_PLACEHOLDER_TEXT,
     selectableColumns: [],
     tabName: "Assemblies",
     url: "/assemblies",
   },
   rawSequencingData: {
     preselectedColumns: [],
+    searchFiltersPlaceholderText: SEARCH_FILTERS_PLACEHOLDER_TEXT,
     selectableColumns: [],
     tabName: "Sequencing Data",
     url: "/raw-sequencing-data",

--- a/e2e/test-readme.md
+++ b/e2e/test-readme.md
@@ -38,21 +38,22 @@ through the actions taken as part of the test and view the impact on the web pag
   - Check that all text that matches a filter regex is clickable, shows a filter menu with checkboxes when clicked, and that the filter menu disapperas when the center of the page is clicked
     - Uses the regex "^(.+)\s+\([0-9]+\)\s\*" to match all filter buttons
     - Once the list of filters is finalized, this should be converted to using a constant list of filters
-    - Runs on all three tabs
+    - Runs on all three tabs except Annotations
   - Check that the filter counts in the filter menus match the resulting row counts for the main table for the first three filters on each tab
     - Once the list of filters is finalized, this should be converted to using a constant list of filters
+  - Check that the filter search bar can be used to select and deselect tests (runs on all four tabs)
 - Sort (`hprc-sort.spec.ts`)
   - Check that clicking the table header of the first row switches the first and last rows in that row
     - Does not check that any actual sorting occurs, only that the first and last rows are switched
-    - Runs on all three tables
+    - Runs on all three tables except Annotations
     - Should be expanded to run on all sortable columns once column names are finalized
 - Navigation
   - Check that all tabs appear on each tab page
-    - Runs on all tabs
+    - Runs on all tabs except Annotations
     - Cannot tell what tabs are selected because the aria-selected value is not set for the tab buttons
     - `hprc-urls.spec.ts`
   - Check that the data table appears on each tab and that the first cell of the first column is visible
-    - Runs on all tabs
+    - Runs on all tabs except Annotations
     - `hprc-table.spec.ts`
   - Check that `/` redirects to `/raw-sequencing-data` (`smoke-test.spec.ts`)
 - All tests rely on correct lists of tabs in `hprc-tabs.ts`

--- a/e2e/testFunctions.ts
+++ b/e2e/testFunctions.ts
@@ -409,7 +409,7 @@ export async function testDeselectFiltersThroughSearchBar(
     const filterOptionNameAndIndex =
       await getFirstNonEmptyFilterOptionNameAndIndex(page);
     const filterOptionName = filterOptionNameAndIndex.name;
-    await filterOptionNameAndIndex.locator.click();
+    await filterOptionNameAndIndex.locator.getByRole("checkbox").click();
     await page.locator("body").click();
     // Search for and check the selected filter
     const searchFiltersInputLocator = page.getByPlaceholder(

--- a/e2e/testFunctions.ts
+++ b/e2e/testFunctions.ts
@@ -298,12 +298,12 @@ const getFirstNonEmptyFilterOptionNameAndIndex = async (
   let filterOptionLocator = undefined;
   let i = 0;
   while (filterToSelect === "" && i < MAX_FILTER_OPTIONS_TO_CHECK) {
-    // Filter options display as "[text]\n[number]" , sometimes with extra whitespace, so we split on newlines and take the first non-empty string
-    const regex = /^(.*)\n+([0-9]+)$/;
+    // Filter options display as "[text]\n[number]" , sometimes with extra whitespace, so we want the string before the newline
+    const filterOptionRegex = /^(.*)\n+([0-9]+)\s*$/;
     filterOptionLocator = getNthFilterOptionLocator(page, i);
     filterToSelect = ((await filterOptionLocator.innerText())
       .trim()
-      .match(regex) ?? ["", ""])[1];
+      .match(filterOptionRegex) ?? ["", ""])[1];
     i += 1;
   }
   if (filterOptionLocator === undefined) {

--- a/e2e/testFunctions.ts
+++ b/e2e/testFunctions.ts
@@ -79,6 +79,26 @@ const getAllFilterNames = async (page: Page): Promise<string[]> => {
 };
 
 /**
+ * Get the names of the first n filters on the page
+ * @param page - a Playwright page object
+ * @param n - the number of filters to test
+ * @returns - true if the test passes and false if the test should fail
+ */
+const getFirstNFilterNames = async (
+  page: Page,
+  n: number
+): Promise<string[]> => {
+  const allFilterNames = await getAllFilterNames(page);
+  if (allFilterNames.length < n) {
+    console.log(
+      `There are only ${allFilterNames.length} filters, which is fewer than the ${n} specified for this test`
+    );
+    return [""];
+  }
+  return allFilterNames.slice(0, n);
+};
+
+/**
  * Test that all text that looks like a filter button is clickable and opens
  * a filter menu with at least one checkbox.
  * This is a temporary test to be used until a permanent list of filter names
@@ -139,15 +159,25 @@ export const getNamedFilterButtonLocator = (
 };
 
 /**
+ * Get a locator for the nth filter option on the page.
+ * @param page - a Playwright page object
+ * @param n - the index of the filter option to get
+ * @returns - a Playwright locator object for the first filter option on the page
+ */
+const getNthFilterOptionLocator = (page: Page, n: number): Locator => {
+  return page
+    .getByRole("button")
+    .filter({ has: page.getByRole("checkbox") })
+    .nth(n);
+};
+
+/**
  * Get a locator for the first filter option on the page.
  * @param page - a Playwright page object
  * @returns - a Playwright locator object for the first filter option on the page
  */
-export const getFirstFilterButtonLocator = (page: Page): Locator => {
-  return page
-    .getByRole("button")
-    .filter({ has: page.getByRole("checkbox") })
-    .first();
+export const getFirstFilterOptionLocator = (page: Page): Locator => {
+  return getNthFilterOptionLocator(page, 0);
 };
 
 /**
@@ -165,14 +195,10 @@ export async function testFirstNFilterCounts(
   n: number
 ): Promise<boolean> {
   await page.goto(tab.url);
-  const allFilterNames = await getAllFilterNames(page);
-  if (allFilterNames.length < n) {
-    console.log(
-      `There are only ${allFilterNames.length} filters, which is fewer than the ${n} specified for this test`
-    );
+  const firstNFilterNames = await getFirstNFilterNames(page, n);
+  if (firstNFilterNames.length < n) {
     return false;
   }
-  const firstNFilterNames = allFilterNames.slice(0, n);
   return await testFilterCounts(page, tab, firstNFilterNames);
 }
 
@@ -208,7 +234,7 @@ export async function testFilterCounts(
     await page.getByText(filterRegex(filterName)).dispatchEvent("click");
     // Get the number associated with the first filter button, and select it
     await page.waitForLoadState("load");
-    const filterButton = getFirstFilterButtonLocator(page);
+    const filterButton = getFirstFilterOptionLocator(page);
     const filterNumbers = (await filterButton.innerText()).split("\n");
     const filterNumber =
       filterNumbers
@@ -232,6 +258,196 @@ export async function testFilterCounts(
       page.getByText("Results 1 - " + firstNumber + " of " + filterNumber)
     ).toBeVisible();
   }
+  return true;
+}
+
+/**
+ * Get a locator for the specified filter option. Requires a filter menu to be open
+ * @param page - a Playwright page object
+ * @param filterOptionName - the name of the filter option
+ * @returns a Playwright locator to the filter button
+ */
+export const getNamedFilterOptionLocator = (
+  page: Page,
+  filterOptionName: string
+): Locator => {
+  // The Regex matches a filter name with a number after it, with potential whitespace before and after the number.
+  // This matches how the innerText in the filter options menu appears to Playwright.
+  return page.getByRole("button").filter({
+    has: page.getByRole("checkbox"),
+    hasText: RegExp(`^${escapeRegExp(filterOptionName)}\\s*\\d+\\s*`),
+  });
+};
+
+interface FilterOptionNameAndLocator {
+  locator: Locator;
+  name: string;
+}
+
+const MAX_FILTER_OPTIONS_TO_CHECK = 10;
+
+/**
+ * Gets the name of the filter option associated with a locator
+ * @param page - a Playwright Page object, on which a filter must be currently selected
+ * @returns the innerText of the first nonempty filter option as a promise
+ */
+const getFirstNonEmptyFilterOptionNameAndIndex = async (
+  page: Page
+): Promise<FilterOptionNameAndLocator> => {
+  let filterToSelect = "";
+  let filterOptionLocator = undefined;
+  let i = 0;
+  while (filterToSelect === "" && i < MAX_FILTER_OPTIONS_TO_CHECK) {
+    // Filter options display as "[text]\n[number]" , sometimes with extra whitespace, so we split on newlines and take the first non-empty string
+    const regex = /^(.*)\n+([0-9]+)$/;
+    filterOptionLocator = getNthFilterOptionLocator(page, i);
+    filterToSelect = ((await filterOptionLocator.innerText())
+      .trim()
+      .match(regex) ?? ["", ""])[1];
+    i += 1;
+  }
+  if (filterOptionLocator === undefined) {
+    throw new Error(
+      "No locator found within the maximum number of filter options"
+    );
+  }
+  return { locator: filterOptionLocator, name: filterToSelect };
+};
+
+const FILTER_CSS_SELECTOR = "#sidebar-positioner";
+
+/**
+ * Get a locator for a named filter tag
+ * @param page - a Playwright page object
+ * @param filterTagName - the name of the filter tag to search for
+ * @returns - a locator for the named filter tag
+ */
+const getFilterTagLocator = (page: Page, filterTagName: string): Locator => {
+  return page
+    .locator(FILTER_CSS_SELECTOR)
+    .getByText(filterTagName, { exact: true });
+};
+
+/**
+ * Run a test that gets the first filter option of each of the filters specified in
+ * filterNames, then attempts to select each through the filter search bar.
+ * @param page - a Playwright page object
+ * @param tab - the Tab object to run the test on
+ * @param filterNames - an array of potential filter names on the selected tab
+ */
+export async function testSelectFiltersThroughSearchBar(
+  page: Page,
+  tab: TabDescription,
+  filterNames: string[]
+): Promise<void> {
+  await page.goto(tab.url);
+  for (const filterName of filterNames) {
+    // Get the first filter option
+    await expect(page.getByText(filterRegex(filterName))).toBeVisible();
+    await page.getByText(filterRegex(filterName)).dispatchEvent("click");
+    const filterOptionName = (
+      await getFirstNonEmptyFilterOptionNameAndIndex(page)
+    ).name;
+    await page.locator("body").click();
+    // Search for the filter option
+    const searchFiltersInputLocator = page.getByPlaceholder(
+      tab.searchFiltersPlaceholderText,
+      { exact: true }
+    );
+    await expect(searchFiltersInputLocator).toBeVisible();
+    await searchFiltersInputLocator.fill(filterOptionName);
+    // Select a filter option with a matching name
+    await getNamedFilterOptionLocator(page, filterOptionName).first().click();
+    await page.locator("body").click();
+    const filterTagLocator = getFilterTagLocator(page, filterOptionName);
+    // Check the filter tag is selected and click it to reset the filter
+    await expect(filterTagLocator).toBeVisible();
+    await filterTagLocator.dispatchEvent("click");
+  }
+}
+
+/**
+ * Runs filter search test for the first n filters on the page
+ * This is a temporary test that should only be used until a final list of
+ * filters is available.
+ * @param page - a Playwright page object
+ * @param tab - the tab object to run the test on
+ * @param n - the number of filters tot est
+ * @returns - true if the test passes and false if the test should fail
+ */
+export async function testSelectFiltersThroughSearchBarForFirstNFilters(
+  page: Page,
+  tab: TabDescription,
+  n: number
+): Promise<boolean> {
+  await page.goto(tab.url);
+  const firstNFilterNames = await getFirstNFilterNames(page, n);
+  if (firstNFilterNames.length < n) {
+    return false;
+  }
+  await testSelectFiltersThroughSearchBar(page, tab, firstNFilterNames);
+  return true;
+}
+
+/**
+ * Run a test that selects the first filter option of each of the filters specified in
+ * filterNames, then attempts to deselect each through the filter search bar.
+ * @param page - a Playwright page object
+ * @param tab - the Tab object to run the test on
+ * @param filterNames - an array of potential filter names on the selected tab
+ */
+export async function testDeselectFiltersThroughSearchBar(
+  page: Page,
+  tab: TabDescription,
+  filterNames: string[]
+): Promise<void> {
+  await page.goto(tab.url);
+  for (const filterName of filterNames) {
+    // Select each filter option
+    await expect(page.getByText(filterRegex(filterName))).toBeVisible();
+    await page.getByText(filterRegex(filterName)).dispatchEvent("click");
+    const filterOptionNameAndIndex =
+      await getFirstNonEmptyFilterOptionNameAndIndex(page);
+    const filterOptionName = filterOptionNameAndIndex.name;
+    await filterOptionNameAndIndex.locator.click();
+    await page.locator("body").click();
+    // Search for and check the selected filter
+    const searchFiltersInputLocator = page.getByPlaceholder(
+      tab.searchFiltersPlaceholderText,
+      { exact: true }
+    );
+    await expect(searchFiltersInputLocator).toBeVisible();
+    await searchFiltersInputLocator.fill(filterOptionName);
+    await getNamedFilterOptionLocator(page, filterOptionName)
+      .locator("input[type='checkbox']:checked")
+      .first()
+      .click();
+    await page.locator("body").click();
+    const filterTagLocator = getFilterTagLocator(page, filterOptionName);
+    await expect(filterTagLocator).not.toBeVisible();
+  }
+}
+
+/**
+ * Runs filter search test for the first n filters on the page
+ * This is a temporary test that should only be used until a final list of
+ * filters is available.
+ * @param page - a Playwright page object
+ * @param tab - the tab object to run the test on
+ * @param n - the number of filters tot est
+ * @returns - true if the test passes and false if the test should fail
+ */
+export async function testDeselectFiltersThroughSearchBarForFirstNFilters(
+  page: Page,
+  tab: TabDescription,
+  n: number
+): Promise<boolean> {
+  await page.goto(tab.url);
+  const firstNFilterNames = await getFirstNFilterNames(page, n);
+  if (firstNFilterNames.length < n) {
+    return false;
+  }
+  await testDeselectFiltersThroughSearchBar(page, tab, firstNFilterNames);
   return true;
 }
 

--- a/e2e/testInterfaces.ts
+++ b/e2e/testInterfaces.ts
@@ -1,5 +1,6 @@
 export interface TabDescription {
   preselectedColumns: columnDescription[];
+  searchFiltersPlaceholderText: string;
   selectableColumns: columnDescription[];
   tabName: string;
   url: string;
@@ -7,6 +8,7 @@ export interface TabDescription {
 
 export interface HprcTabCollection {
   alignments: TabDescription;
+  annotations: TabDescription;
   assemblies: TabDescription;
   rawSequencingData: TabDescription;
 }


### PR DESCRIPTION
- Added filter search tests to HPRC as follows:
  1. Click into the search all filters box 
  2. Verify the box opens
  3. Select the first element in box that is not associated with blank text
  4. Verify the filter tag appears.
  5. Verify the count in the facet filter matches the count on the table e.g. "Results 1-2 of 2".
- Added Annotations tab to tab descriptions, but did not update existing tests to use it