### PR TITLE
feat: add chart view (#140)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "hprc-data-explorer",
       "version": "0.0.0",
       "dependencies": {
-        "@databiosphere/findable-ui": "^28.0.0",
+        "@databiosphere/findable-ui": "^28.0.1",
         "@emotion/react": "^11.13.0",
         "@emotion/styled": "^11.13.0",
         "@mdx-js/loader": "^3.0.1",
@@ -2356,9 +2356,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "28.0.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-28.0.0.tgz",
-      "integrity": "sha512-fVKxTP3nPEmMjLkwCnLLmhF+5Zs2bfTP3dJRph4qwidpDNeCbLw9k2I2by5bZADrcqOQo0vMSaIxn0ZKtngAvQ==",
+      "version": "28.0.1",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-28.0.1.tgz",
+      "integrity": "sha512-vjFrss0orPKfczjyybg0pHSoJF5gkf58HIVMKfPAM56E3QaP/DennBLHWzwUcFVWBiIjfpsxIof+l/9URMaOUQ==",
       "engines": {
         "node": "20.10.0"
       },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "gen-schema": "poetry run ./catalog/schema/scripts/gen-schema.sh"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^28.0.0",
+    "@databiosphere/findable-ui": "^28.0.1",
     "@emotion/react": "^11.13.0",
     "@emotion/styled": "^11.13.0",
     "@mdx-js/loader": "^3.0.1",

--- a/site-config/hprc-data-explorer/local/config.ts
+++ b/site-config/hprc-data-explorer/local/config.ts
@@ -22,6 +22,7 @@ export function makeConfig(browserUrl: string, gitHubUrl: string): SiteConfig {
     dataSource: {
       url: "",
     },
+    enableEntitiesView: true,
     entities: [
       rawSequencingDataEntityConfig,
       assemblyEntityConfig,

--- a/site-config/hprc-data-explorer/local/index/alignmentEntityConfig.ts
+++ b/site-config/hprc-data-explorer/local/index/alignmentEntityConfig.ts
@@ -23,6 +23,7 @@ export const alignmentEntityConfig: EntityConfig<HPRCDataExplorerAlignment> = {
       {
         categoryConfigs: [
           {
+            enableChartView: false,
             key: HPRC_DATA_EXPLORER_CATEGORY_KEY.ALIGNMENT,
             label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.ALIGNMENT,
           },
@@ -39,6 +40,7 @@ export const alignmentEntityConfig: EntityConfig<HPRCDataExplorerAlignment> = {
             label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.REFERENCE_COORDINATES,
           },
           {
+            enableChartView: false,
             key: HPRC_DATA_EXPLORER_CATEGORY_KEY.FILENAME,
             label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.FILENAME,
           },

--- a/site-config/hprc-data-explorer/local/index/annotationEntityConfig.ts
+++ b/site-config/hprc-data-explorer/local/index/annotationEntityConfig.ts
@@ -24,14 +24,17 @@ export const annotationEntityConfig: EntityConfig<HPRCDataExplorerAnnotation> =
         {
           categoryConfigs: [
             {
+              enableChartView: false,
               key: HPRC_DATA_EXPLORER_CATEGORY_KEY.RELEASE,
               label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.RELEASE,
             },
             {
+              enableChartView: false,
               key: HPRC_DATA_EXPLORER_CATEGORY_KEY.SAMPLE_ID,
               label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.SAMPLE_ID,
             },
             {
+              enableChartView: false,
               key: HPRC_DATA_EXPLORER_CATEGORY_KEY.HAPLOTYPE,
               label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.HAPLOTYPE,
             },

--- a/site-config/hprc-data-explorer/local/index/assemblyEntityConfig.ts
+++ b/site-config/hprc-data-explorer/local/index/assemblyEntityConfig.ts
@@ -27,10 +27,12 @@ export const assemblyEntityConfig: EntityConfig<HPRCDataExplorerAssembly> = {
             label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.RELEASE,
           },
           {
+            enableChartView: false,
             key: HPRC_DATA_EXPLORER_CATEGORY_KEY.SAMPLE_ID,
             label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.SAMPLE_ID,
           },
           {
+            enableChartView: false,
             key: HPRC_DATA_EXPLORER_CATEGORY_KEY.BIOSAMPLE_ACCESSION,
             label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.BIOSAMPLE_ACCESSION,
           },

--- a/site-config/hprc-data-explorer/local/index/rawSequencingDataEntityConfig.ts
+++ b/site-config/hprc-data-explorer/local/index/rawSequencingDataEntityConfig.ts
@@ -24,6 +24,7 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
         {
           categoryConfigs: [
             {
+              enableChartView: false,
               key: HPRC_DATA_EXPLORER_CATEGORY_KEY.BIOSAMPLE_ACCESSION,
               label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.BIOSAMPLE_ACCESSION,
             },
@@ -33,6 +34,7 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
         {
           categoryConfigs: [
             {
+              enableChartView: false,
               key: HPRC_DATA_EXPLORER_CATEGORY_KEY.SAMPLE_ID,
               label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.SAMPLE_ID,
             },


### PR DESCRIPTION
Closes #140.

This pull request introduces updates to dependencies and configuration changes to the HPRC Data Explorer. The key updates include upgrading the `@databiosphere/findable-ui` dependency, enabling the entities view, and adding a new `enableChartView` property to various entity configurations.

### Dependency Updates:
* Updated `@databiosphere/findable-ui` dependency from `^28.0.0` to `^28.0.1` in `package.json`.

### Configuration Changes:
* Enabled the entities view by adding the `enableEntitiesView` property in `site-config/hprc-data-explorer/local/config.ts`.

### Entity Config Updates:
* Added the `enableChartView` property (set to `false`) to multiple entity configurations across different files:
  - `alignmentEntityConfig` in `site-config/hprc-data-explorer/local/index/alignmentEntityConfig.ts`. [[1]](diffhunk://#diff-44ed41c32147e3a1bfd26b92d3427055de6a910c308f037223d67a46b2783291R26) [[2]](diffhunk://#diff-44ed41c32147e3a1bfd26b92d3427055de6a910c308f037223d67a46b2783291R43)
  - `annotationEntityConfig` in `site-config/hprc-data-explorer/local/index/annotationEntityConfig.ts`.
  - `assemblyEntityConfig` in `site-config/hprc-data-explorer/local/index/assemblyEntityConfig.ts`.
  - `rawSequencingDataEntityConfig` in `site-config/hprc-data-explorer/local/index/rawSequencingDataEntityConfig.ts`. [[1]](diffhunk://#diff-cd7765a7089b3e8f2b96ddbffc66006268b1a4aecf4e818d8a60258442a73220R27) [[2]](diffhunk://#diff-cd7765a7089b3e8f2b96ddbffc66006268b1a4aecf4e818d8a60258442a73220R37)

<img width="1720" alt="image" src="https://github.com/user-attachments/assets/c4f664e2-344b-4ba6-bcf3-16b4163f2909" />
