### PR TITLE
feat: added annotation list hero #150

### DIFF
--- a/app/components/common/MDXContent/alertAnnotationListHero.mdx
+++ b/app/components/common/MDXContent/alertAnnotationListHero.mdx
@@ -1,0 +1,4 @@
+<Alert component={props.component} severity={props.severity}>
+  Note: v2.0 resources are being progressively added. Where v2.0 versions are
+  not yet available, we advise using the v1.1 release.
+</Alert>

--- a/app/components/common/MDXContent/index.tsx
+++ b/app/components/common/MDXContent/index.tsx
@@ -1,0 +1,1 @@
+export { default as AlertAnnotationListHero } from "./alertAnnotationListHero.mdx";

--- a/app/components/index.ts
+++ b/app/components/index.ts
@@ -1,3 +1,5 @@
+export { Alert } from "@databiosphere/findable-ui/lib/components/common/Alert/alert";
+export { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
 export { GitHubIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/GitHubIcon/gitHubIcon";
 export { Logo } from "@databiosphere/findable-ui/lib/components/Layout/components/Header/components/Content/components/Logo/logo";
 export { BasicCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/BasicCell/basicCell";

--- a/app/viewModelBuilders/catalog/hprc-data-explorer/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hprc-data-explorer/common/viewModelBuilders.ts
@@ -8,6 +8,9 @@ import {
   LABEL,
 } from "../../../../apis/catalog/hprc-data-explorer/common/entities";
 import * as C from "../../../../components/index";
+import { ViewContext } from "@databiosphere/findable-ui/lib/config/entities";
+import * as MDX from "../../../../components/common/MDXContent";
+import { ALERT_PROPS } from "@databiosphere/findable-ui/lib/components/common/Alert/constants";
 
 /**
  * Build props for the alignment cell.
@@ -47,6 +50,23 @@ export const buildAnnotationDownload = (
   return {
     fileName: annotation.filename,
     fileUrl: getDownloadUrl(annotation.fileLocation),
+  };
+};
+
+/**
+ * Build props for annotation list view info Alert component.
+ * @param _ - Unused.
+ * @param viewContext - View context.
+ * @returns model to be used as props for the Alert component.
+ */
+export const buildAnnotationListHero = (
+  _: unknown,
+  viewContext: ViewContext<unknown>
+): React.ComponentProps<typeof MDX.AlertAnnotationListHero> => {
+  return {
+    ...ALERT_PROPS.STANDARD_INFO,
+    component: C.FluidPaper,
+    entityName: viewContext.entityConfig.label,
   };
 };
 

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -1,0 +1,9 @@
+import { MDXComponents } from "mdx/types";
+import * as C from "./app/components";
+
+export function useMDXComponents(components: MDXComponents): MDXComponents {
+  return {
+    ...components,
+    Alert: C.Alert,
+  };
+}

--- a/site-config/hprc-data-explorer/local/index/annotationEntityConfig.ts
+++ b/site-config/hprc-data-explorer/local/index/annotationEntityConfig.ts
@@ -13,6 +13,7 @@ import {
   HPRC_DATA_EXPLORER_CATEGORY_KEY,
   HPRC_DATA_EXPLORER_CATEGORY_LABEL,
 } from "../../category";
+import { annotationListHero } from "../listView/annotationListHero";
 
 /**
  * Entity config object responsible to config anything related to the /annotations route.
@@ -165,6 +166,7 @@ export const annotationEntityConfig: EntityConfig<HPRCDataExplorerAnnotation> =
       disablePagination: true,
       enableDownload: true,
       enableTab: false,
+      listHero: annotationListHero,
     },
     route: "annotations",
     staticLoadFile: "catalog/output/annotations.json",

--- a/site-config/hprc-data-explorer/local/listView/annotationListHero.ts
+++ b/site-config/hprc-data-explorer/local/listView/annotationListHero.ts
@@ -1,0 +1,13 @@
+import {
+  ComponentConfig,
+  ComponentsConfig,
+} from "@databiosphere/findable-ui/lib/config/entities";
+import * as MDX from "../../../../app/components/common/MDXContent";
+import * as V from "../../../../app/viewModelBuilders/catalog/hprc-data-explorer/common/viewModelBuilders";
+
+export const annotationListHero: ComponentsConfig = [
+  {
+    component: MDX.AlertAnnotationListHero,
+    viewBuilder: V.buildAnnotationListHero,
+  } as ComponentConfig<typeof MDX.AlertAnnotationListHero>,
+];


### PR DESCRIPTION
This pull request introduces a new `Alert` component to display annotation-related information and integrates it into the annotation list view. The changes include creating a reusable MDX component, updating the view model builders, and configuring the site to use this component in the annotation list view.

### Addition of the `Alert` Component:
* [`app/components/common/MDXContent/alertAnnotationListHero.mdx`](diffhunk://#diff-0a9966700f9a500f1ebcba6d716cf784c18f10e1a00a5787afe5022603e98a28R1-R4): Added a new `AlertAnnotationListHero` component to display a note about v2.0 resources.
* [`app/components/common/MDXContent/index.tsx`](diffhunk://#diff-bf7f33e3b9a9fda1b9a7f0d0c2d11512cbcfb7902d520f3ad7e9fda606cf95aaR1): Exported the new `AlertAnnotationListHero` component.
* [`mdx-components.tsx`](diffhunk://#diff-00760c96c632d58f2c4862219a590c7fb40fa5d8c2365c3d26c3cf8e8d95012eR1-R9): Added support for rendering the `Alert` component in MDX files.

### Integration with the Annotation List View:
* [`app/viewModelBuilders/catalog/hprc-data-explorer/common/viewModelBuilders.ts`](diffhunk://#diff-c936b346aac013d5a2f8665c56324e458db90b11fa57d282f503c3e507fa66efR56-R72): Added a `buildAnnotationListHero` function to generate props for the `AlertAnnotationListHero` component.
* [`site-config/hprc-data-explorer/local/listView/annotationListHero.ts`](diffhunk://#diff-1aaed28fa4b53ae14f333688bb7a65e490b22ca5fb7bdf5df6e6ff5a64307aaeR1-R13): Configured the `annotationListHero` to use the `AlertAnnotationListHero` component with the new view builder.
* [`site-config/hprc-data-explorer/local/index/annotationEntityConfig.ts`](diffhunk://#diff-dee479e10676f0f4b4d608af63cd6eff3034a2d8f1d3f2373fe32c54439f9822R169): Linked the `annotationListHero` configuration to the annotation entity.

### Supporting Changes:
* [`app/components/index.ts`](diffhunk://#diff-ab5acd52d2bbe58facfe338cfed6cec00e93a9e328a89b7f9e0d9c6867745d8dR1-R2): Exported the `Alert` and `FluidPaper` components from the `@databiosphere/findable-ui` library for reuse.
* [`app/viewModelBuilders/catalog/hprc-data-explorer/common/viewModelBuilders.ts`](diffhunk://#diff-c936b346aac013d5a2f8665c56324e458db90b11fa57d282f503c3e507fa66efR11-R13): Imported necessary constants and components for the new functionality.
* [`site-config/hprc-data-explorer/local/index/annotationEntityConfig.ts`](diffhunk://#diff-dee479e10676f0f4b4d608af63cd6eff3034a2d8f1d3f2373fe32c54439f9822R16): Imported the `annotationListHero` configuration.#### Ticket
Closes #150.

#### Updates
<img width="1601" alt="image" src="https://github.com/user-attachments/assets/2cd9d7b0-b448-4e5b-98ef-479db73276b0" />
