### PR TITLE
fix: refactor resources banner from annotations to alignments (#156)

### DIFF
--- a/site-config/hprc-data-explorer/local/index/alignment/listView/listHero.ts
+++ b/site-config/hprc-data-explorer/local/index/alignment/listView/listHero.ts
@@ -2,10 +2,10 @@ import {
   ComponentConfig,
   ComponentsConfig,
 } from "@databiosphere/findable-ui/lib/config/entities";
-import * as MDX from "../../../../app/components/common/MDXContent";
-import * as V from "../../../../app/viewModelBuilders/catalog/hprc-data-explorer/common/viewModelBuilders";
+import * as MDX from "../../../../../../app/components/common/MDXContent";
+import * as V from "../../../../../../app/viewModelBuilders/catalog/hprc-data-explorer/common/viewModelBuilders";
 
-export const annotationListHero: ComponentsConfig = [
+export const listHero: ComponentsConfig = [
   {
     component: MDX.AlertAnnotationListHero,
     viewBuilder: V.buildAnnotationListHero,

--- a/site-config/hprc-data-explorer/local/index/alignmentEntityConfig.ts
+++ b/site-config/hprc-data-explorer/local/index/alignmentEntityConfig.ts
@@ -13,6 +13,7 @@ import {
   HPRC_DATA_EXPLORER_CATEGORY_KEY,
   HPRC_DATA_EXPLORER_CATEGORY_LABEL,
 } from "../../category";
+import { listHero } from "./alignment/listView/listHero";
 
 /**
  * Entity config object responsible to config anything related to the /alignments route.
@@ -169,6 +170,7 @@ export const alignmentEntityConfig: EntityConfig<HPRCDataExplorerAlignment> = {
     disablePagination: true,
     enableDownload: true,
     enableTab: false,
+    listHero,
   },
   route: "alignments",
   staticLoadFile: "catalog/output/alignments.json",

--- a/site-config/hprc-data-explorer/local/index/annotationEntityConfig.ts
+++ b/site-config/hprc-data-explorer/local/index/annotationEntityConfig.ts
@@ -13,7 +13,6 @@ import {
   HPRC_DATA_EXPLORER_CATEGORY_KEY,
   HPRC_DATA_EXPLORER_CATEGORY_LABEL,
 } from "../../category";
-import { annotationListHero } from "../listView/annotationListHero";
 
 /**
  * Entity config object responsible to config anything related to the /annotations route.
@@ -166,7 +165,6 @@ export const annotationEntityConfig: EntityConfig<HPRCDataExplorerAnnotation> =
       disablePagination: true,
       enableDownload: true,
       enableTab: false,
-      listHero: annotationListHero,
     },
     route: "annotations",
     staticLoadFile: "catalog/output/annotations.json",


### PR DESCRIPTION
Closes #156.

This pull request refactors and renames the `annotationListHero` component to `listHero` for better reusability and updates its references across the codebase. It also adjusts import paths to reflect the new file structure.

### Component Refactoring:
* Renamed `annotationListHero` to `listHero` and updated its export in `site-config/hprc-data-explorer/local/index/alignment/listView/listHero.ts` (previously `annotationListHero.ts`).

### Import Path Updates:
* Updated import paths in `listHero.ts` to reflect the new file structure.

### Usage Updates:
* Added `listHero` to the `alignmentEntityConfig` in `site-config/hprc-data-explorer/local/index/alignmentEntityConfig.ts`. [[1]](diffhunk://#diff-44ed41c32147e3a1bfd26b92d3427055de6a910c308f037223d67a46b2783291R16) [[2]](diffhunk://#diff-44ed41c32147e3a1bfd26b92d3427055de6a910c308f037223d67a46b2783291R173)
* Removed the `annotationListHero` import and its usage from `annotationEntityConfig` in `site-config/hprc-data-explorer/local/index/annotationEntityConfig.ts`. [[1]](diffhunk://#diff-dee479e10676f0f4b4d608af63cd6eff3034a2d8f1d3f2373fe32c54439f9822L16) [[2]](diffhunk://#diff-dee479e10676f0f4b4d608af63cd6eff3034a2d8f1d3f2373fe32c54439f9822L169)

<img width="1566" alt="image" src="https://github.com/user-attachments/assets/b852d4eb-6239-4a1f-bb2e-f8489ee5b5dc" />
