### PR TITLE
feat: validate that source files don't contain slots used by the broader model but not the specific class (#183)

### DIFF
--- a/catalog/build/py/build_help.py
+++ b/catalog/build/py/build_help.py
@@ -79,7 +79,7 @@ def check_non_applicable_slots(source_row_dict, row_index, model, schemaview):
     model_field_names = get_pydantic_field_names(model)
     non_applicable_slots = [name for name in schemaview.all_slots().keys() if name in source_row_dict and name not in model_field_names]
     if non_applicable_slots:
-        raise HprcMultiFieldValidationError("Specified slot in schema but not class", row_index, non_applicable_slots)
+        raise HprcMultiFieldValidationError("Specified slot is in the broader model but not the specific class", row_index, non_applicable_slots)
 
 def validate_row(source_row_dict, row_index, field_type_mappers, model, schemaview):
     errors = []


### PR DESCRIPTION
This pull request refactors the validation logic in `catalog/build/py/build_help.py` to improve error handling and introduce checks for non-applicable slots. The key changes include replacing the `HprcSourceFileValidationError` class with `HprcMultiFieldValidationError`, adding a new function to validate non-applicable slots, and updating the row validation flow to handle multiple error types.

### Error handling improvements:
* **Replaced `HprcSourceFileValidationError` with `HprcMultiFieldValidationError`:** The new class now accepts `row` and `fields` instead of `filename` and `errors`, aligning with the updated validation logic. (`[catalog/build/py/build_help.pyL17-R22](diffhunk://#diff-7074aa40828ab355d31dc30eb25352a5c3ae0cbffa20ca448f476f628e0d84ecL17-R22)`)

### Validation logic enhancements:
* **Added `check_non_applicable_slots` function:** This function identifies and raises errors for slots that exist in the broader model but not in the specific class, improving schema validation. (`[catalog/build/py/build_help.pyL78-R109](diffhunk://#diff-7074aa40828ab355d31dc30eb25352a5c3ae0cbffa20ca448f476f628e0d84ecL78-R109)`)
* **Updated `validate_row` function:** Integrated the `check_non_applicable_slots` function and enhanced error aggregation to handle multiple error types, including non-applicable slots and field validation errors. (`[catalog/build/py/build_help.pyL78-R109](diffhunk://#diff-7074aa40828ab355d31dc30eb25352a5c3ae0cbffa20ca448f476f628e0d84ecL78-R109)`)
* **Modified `validate_and_normalize_df` function:** Updated the call to `validate_row` to pass the `schemaview` parameter, ensuring compatibility with the new validation logic. (`[catalog/build/py/build_help.pyL78-R109](diffhunk://#diff-7074aa40828ab355d31dc30eb25352a5c3ae0cbffa20ca448f476f628e0d84ecL78-R109)`)Closes #183