### PR TITLE
chore: build catalog data for updated cat annotations (#211)

### DIFF
--- a/catalog/build/intermediate/annotations.csv
+++ b/catalog/build/intermediate/annotations.csv
@@ -1,98 +1,98 @@
 sample_id,haplotype,location,annotation_type,release,assembly_name,file_size
-HG002,2,s3://human-pangenomics/working/HPRC_PLUS/HG002/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG002-maternal.bed,ASat,1,N/A,N/A
-HG002,1,s3://human-pangenomics/working/HPRC_PLUS/HG002/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG002-paternal.bed,ASat,1,N/A,N/A
-HG00438,2,s3://human-pangenomics/working/HPRC/HG00438/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00438-maternal.bed,ASat,1,N/A,N/A
-HG00438,1,s3://human-pangenomics/working/HPRC/HG00438/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00438-paternal.bed,ASat,1,N/A,N/A
-HG005,2,s3://human-pangenomics/working/HPRC_PLUS/HG005/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG005-maternal.bed,ASat,1,N/A,N/A
-HG005,1,s3://human-pangenomics/working/HPRC_PLUS/HG005/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG005-paternal.bed,ASat,1,N/A,N/A
-HG00621,2,s3://human-pangenomics/working/HPRC/HG00621/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00621-maternal.bed,ASat,1,N/A,N/A
-HG00621,1,s3://human-pangenomics/working/HPRC/HG00621/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00621-paternal.bed,ASat,1,N/A,N/A
-HG00673,2,s3://human-pangenomics/working/HPRC/HG00673/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00673-maternal.bed,ASat,1,N/A,N/A
-HG00673,1,s3://human-pangenomics/working/HPRC/HG00673/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00673-paternal.bed,ASat,1,N/A,N/A
-HG00733,2,s3://human-pangenomics/working/HPRC_PLUS/HG00733/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00733-maternal.bed,ASat,1,N/A,N/A
-HG00733,1,s3://human-pangenomics/working/HPRC_PLUS/HG00733/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00733-paternal.bed,ASat,1,N/A,N/A
-HG00735,2,s3://human-pangenomics/working/HPRC/HG00735/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00735-maternal.bed,ASat,1,N/A,N/A
-HG00735,1,s3://human-pangenomics/working/HPRC/HG00735/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00735-paternal.bed,ASat,1,N/A,N/A
-HG00741,2,s3://human-pangenomics/working/HPRC/HG00741/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00741-maternal.bed,ASat,1,N/A,N/A
-HG00741,1,s3://human-pangenomics/working/HPRC/HG00741/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00741-paternal.bed,ASat,1,N/A,N/A
-HG01071,2,s3://human-pangenomics/working/HPRC/HG01071/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01071-maternal.bed,ASat,1,N/A,N/A
-HG01071,1,s3://human-pangenomics/working/HPRC/HG01071/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01071-paternal.bed,ASat,1,N/A,N/A
-HG01106,2,s3://human-pangenomics/working/HPRC/HG01106/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01106-maternal.bed,ASat,1,N/A,N/A
-HG01106,1,s3://human-pangenomics/working/HPRC/HG01106/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01106-paternal.bed,ASat,1,N/A,N/A
-HG01109,2,s3://human-pangenomics/working/HPRC_PLUS/HG01109/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01109-maternal.bed,ASat,1,N/A,N/A
-HG01109,1,s3://human-pangenomics/working/HPRC_PLUS/HG01109/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01109-paternal.bed,ASat,1,N/A,N/A
-HG01123,2,s3://human-pangenomics/working/HPRC/HG01123/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01123-maternal.bed,ASat,1,N/A,N/A
-HG01123,1,s3://human-pangenomics/working/HPRC/HG01123/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01123-paternal.bed,ASat,1,N/A,N/A
-HG01175,2,s3://human-pangenomics/working/HPRC/HG01175/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01175-maternal.bed,ASat,1,N/A,N/A
-HG01175,1,s3://human-pangenomics/working/HPRC/HG01175/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01175-paternal.bed,ASat,1,N/A,N/A
-HG01243,2,s3://human-pangenomics/working/HPRC_PLUS/HG01243/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01243-maternal.bed,ASat,1,N/A,N/A
-HG01243,1,s3://human-pangenomics/working/HPRC_PLUS/HG01243/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01243-paternal.bed,ASat,1,N/A,N/A
-HG01258,2,s3://human-pangenomics/working/HPRC/HG01258/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01258-maternal.bed,ASat,1,N/A,N/A
-HG01258,1,s3://human-pangenomics/working/HPRC/HG01258/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01258-paternal.bed,ASat,1,N/A,N/A
-HG01358,2,s3://human-pangenomics/working/HPRC/HG01358/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01358-maternal.bed,ASat,1,N/A,N/A
-HG01358,1,s3://human-pangenomics/working/HPRC/HG01358/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01358-paternal.bed,ASat,1,N/A,N/A
-HG01361,2,s3://human-pangenomics/working/HPRC/HG01361/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01361-maternal.bed,ASat,1,N/A,N/A
-HG01361,1,s3://human-pangenomics/working/HPRC/HG01361/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01361-paternal.bed,ASat,1,N/A,N/A
-HG01891,2,s3://human-pangenomics/working/HPRC/HG01891/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01891-maternal.bed,ASat,1,N/A,N/A
-HG01891,1,s3://human-pangenomics/working/HPRC/HG01891/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01891-paternal.bed,ASat,1,N/A,N/A
-HG01928,2,s3://human-pangenomics/working/HPRC/HG01928/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01928-maternal.bed,ASat,1,N/A,N/A
-HG01928,1,s3://human-pangenomics/working/HPRC/HG01928/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01928-paternal.bed,ASat,1,N/A,N/A
-HG01952,2,s3://human-pangenomics/working/HPRC/HG01952/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01952-maternal.bed,ASat,1,N/A,N/A
-HG01952,1,s3://human-pangenomics/working/HPRC/HG01952/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01952-paternal.bed,ASat,1,N/A,N/A
-HG01978,2,s3://human-pangenomics/working/HPRC/HG01978/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01978-maternal.bed,ASat,1,N/A,N/A
-HG01978,1,s3://human-pangenomics/working/HPRC/HG01978/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01978-paternal.bed,ASat,1,N/A,N/A
-HG02055,2,s3://human-pangenomics/working/HPRC_PLUS/HG02055/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02055-maternal.bed,ASat,1,N/A,N/A
-HG02055,1,s3://human-pangenomics/working/HPRC_PLUS/HG02055/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02055-paternal.bed,ASat,1,N/A,N/A
-HG02080,2,s3://human-pangenomics/working/HPRC_PLUS/HG02080/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02080-maternal.bed,ASat,1,N/A,N/A
-HG02080,1,s3://human-pangenomics/working/HPRC_PLUS/HG02080/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02080-paternal.bed,ASat,1,N/A,N/A
-HG02109,2,s3://human-pangenomics/working/HPRC_PLUS/HG02109/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02109-maternal.bed,ASat,1,N/A,N/A
-HG02109,1,s3://human-pangenomics/working/HPRC_PLUS/HG02109/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02109-paternal.bed,ASat,1,N/A,N/A
-HG02145,2,s3://human-pangenomics/working/HPRC_PLUS/HG02145/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02145-maternal.bed,ASat,1,N/A,N/A
-HG02145,1,s3://human-pangenomics/working/HPRC_PLUS/HG02145/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02145-paternal.bed,ASat,1,N/A,N/A
-HG02148,2,s3://human-pangenomics/working/HPRC/HG02148/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02148-maternal.bed,ASat,1,N/A,N/A
-HG02148,1,s3://human-pangenomics/working/HPRC/HG02148/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02148-paternal.bed,ASat,1,N/A,N/A
-HG02257,2,s3://human-pangenomics/working/HPRC/HG02257/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02257-maternal.bed,ASat,1,N/A,N/A
-HG02257,1,s3://human-pangenomics/working/HPRC/HG02257/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02257-paternal.bed,ASat,1,N/A,N/A
-HG02486,2,s3://human-pangenomics/working/HPRC/HG02486/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02486-maternal.bed,ASat,1,N/A,N/A
-HG02486,1,s3://human-pangenomics/working/HPRC/HG02486/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02486-paternal.bed,ASat,1,N/A,N/A
-HG02559,2,s3://human-pangenomics/working/HPRC/HG02559/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02559-maternal.bed,ASat,1,N/A,N/A
-HG02559,1,s3://human-pangenomics/working/HPRC/HG02559/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02559-paternal.bed,ASat,1,N/A,N/A
-HG02572,2,s3://human-pangenomics/working/HPRC/HG02572/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02572-maternal.bed,ASat,1,N/A,N/A
-HG02572,1,s3://human-pangenomics/working/HPRC/HG02572/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02572-paternal.bed,ASat,1,N/A,N/A
-HG02622,2,s3://human-pangenomics/working/HPRC/HG02622/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02622-maternal.bed,ASat,1,N/A,N/A
-HG02622,1,s3://human-pangenomics/working/HPRC/HG02622/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02622-paternal.bed,ASat,1,N/A,N/A
-HG02630,2,s3://human-pangenomics/working/HPRC/HG02630/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02630-maternal.bed,ASat,1,N/A,N/A
-HG02630,1,s3://human-pangenomics/working/HPRC/HG02630/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02630-paternal.bed,ASat,1,N/A,N/A
-HG02717,2,s3://human-pangenomics/working/HPRC/HG02717/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02717-maternal.bed,ASat,1,N/A,N/A
-HG02717,1,s3://human-pangenomics/working/HPRC/HG02717/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02717-paternal.bed,ASat,1,N/A,N/A
-HG02723,2,s3://human-pangenomics/working/HPRC_PLUS/HG02723/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02723-maternal.bed,ASat,1,N/A,N/A
-HG02723,1,s3://human-pangenomics/working/HPRC_PLUS/HG02723/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02723-paternal.bed,ASat,1,N/A,N/A
-HG02818,2,s3://human-pangenomics/working/HPRC_PLUS/HG02818/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02818-maternal.bed,ASat,1,N/A,N/A
-HG02818,1,s3://human-pangenomics/working/HPRC_PLUS/HG02818/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02818-paternal.bed,ASat,1,N/A,N/A
-HG02886,2,s3://human-pangenomics/working/HPRC/HG02886/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02886-maternal.bed,ASat,1,N/A,N/A
-HG02886,1,s3://human-pangenomics/working/HPRC/HG02886/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02886-paternal.bed,ASat,1,N/A,N/A
-HG03098,2,s3://human-pangenomics/working/HPRC_PLUS/HG03098/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03098-maternal.bed,ASat,1,N/A,N/A
-HG03098,1,s3://human-pangenomics/working/HPRC_PLUS/HG03098/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03098-paternal.bed,ASat,1,N/A,N/A
-HG03453,2,s3://human-pangenomics/working/HPRC/HG03453/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03453-maternal.bed,ASat,1,N/A,N/A
-HG03453,1,s3://human-pangenomics/working/HPRC/HG03453/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03453-paternal.bed,ASat,1,N/A,N/A
-HG03486,2,s3://human-pangenomics/working/HPRC_PLUS/HG03486/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03486-maternal.bed,ASat,1,N/A,N/A
-HG03486,1,s3://human-pangenomics/working/HPRC_PLUS/HG03486/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03486-paternal.bed,ASat,1,N/A,N/A
-HG03492,2,s3://human-pangenomics/working/HPRC_PLUS/HG03492/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03492-maternal.bed,ASat,1,N/A,N/A
-HG03492,1,s3://human-pangenomics/working/HPRC_PLUS/HG03492/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03492-paternal.bed,ASat,1,N/A,N/A
-HG03516,2,s3://human-pangenomics/working/HPRC/HG03516/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03516-maternal.bed,ASat,1,N/A,N/A
-HG03516,1,s3://human-pangenomics/working/HPRC/HG03516/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03516-paternal.bed,ASat,1,N/A,N/A
-HG03540,2,s3://human-pangenomics/working/HPRC/HG03540/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03540-maternal.bed,ASat,1,N/A,N/A
-HG03540,1,s3://human-pangenomics/working/HPRC/HG03540/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03540-paternal.bed,ASat,1,N/A,N/A
-HG03579,2,s3://human-pangenomics/working/HPRC/HG03579/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03579-maternal.bed,ASat,1,N/A,N/A
-HG03579,1,s3://human-pangenomics/working/HPRC/HG03579/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03579-paternal.bed,ASat,1,N/A,N/A
-NA18906,2,s3://human-pangenomics/working/HPRC_PLUS/NA18906/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-NA18906-maternal.bed,ASat,1,N/A,N/A
-NA18906,1,s3://human-pangenomics/working/HPRC_PLUS/NA18906/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-NA18906-paternal.bed,ASat,1,N/A,N/A
-NA19240,2,s3://human-pangenomics/working/HPRC_PLUS/NA19240/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-NA19240-maternal.bed,ASat,1,N/A,N/A
-NA19240,1,s3://human-pangenomics/working/HPRC_PLUS/NA19240/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-NA19240-paternal.bed,ASat,1,N/A,N/A
-NA20129,2,s3://human-pangenomics/working/HPRC_PLUS/NA20129/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-NA20129-maternal.bed,ASat,1,N/A,N/A
-NA20129,1,s3://human-pangenomics/working/HPRC_PLUS/NA20129/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-NA20129-paternal.bed,ASat,1,N/A,N/A
-NA21309,2,s3://human-pangenomics/working/HPRC_PLUS/NA21309/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-NA21309-maternal.bed,ASat,1,N/A,N/A
-NA21309,1,s3://human-pangenomics/working/HPRC_PLUS/NA21309/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-NA21309-paternal.bed,ASat,1,N/A,N/A
+HG002,2,s3://human-pangenomics/working/HPRC_PLUS/HG002/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG002-maternal.bed,ASat,1,N/A,53066037
+HG002,1,s3://human-pangenomics/working/HPRC_PLUS/HG002/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG002-paternal.bed,ASat,1,N/A,52893924
+HG00438,2,s3://human-pangenomics/working/HPRC/HG00438/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00438-maternal.bed,ASat,1,N/A,52488458
+HG00438,1,s3://human-pangenomics/working/HPRC/HG00438/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00438-paternal.bed,ASat,1,N/A,45400685
+HG005,2,s3://human-pangenomics/working/HPRC_PLUS/HG005/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG005-maternal.bed,ASat,1,N/A,49721906
+HG005,1,s3://human-pangenomics/working/HPRC_PLUS/HG005/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG005-paternal.bed,ASat,1,N/A,47646544
+HG00621,2,s3://human-pangenomics/working/HPRC/HG00621/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00621-maternal.bed,ASat,1,N/A,49950273
+HG00621,1,s3://human-pangenomics/working/HPRC/HG00621/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00621-paternal.bed,ASat,1,N/A,48192701
+HG00673,2,s3://human-pangenomics/working/HPRC/HG00673/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00673-maternal.bed,ASat,1,N/A,54640824
+HG00673,1,s3://human-pangenomics/working/HPRC/HG00673/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00673-paternal.bed,ASat,1,N/A,49457289
+HG00733,2,s3://human-pangenomics/working/HPRC_PLUS/HG00733/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00733-maternal.bed,ASat,1,N/A,44744178
+HG00733,1,s3://human-pangenomics/working/HPRC_PLUS/HG00733/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00733-paternal.bed,ASat,1,N/A,48297600
+HG00735,2,s3://human-pangenomics/working/HPRC/HG00735/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00735-maternal.bed,ASat,1,N/A,50878360
+HG00735,1,s3://human-pangenomics/working/HPRC/HG00735/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00735-paternal.bed,ASat,1,N/A,48277913
+HG00741,2,s3://human-pangenomics/working/HPRC/HG00741/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00741-maternal.bed,ASat,1,N/A,46458721
+HG00741,1,s3://human-pangenomics/working/HPRC/HG00741/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00741-paternal.bed,ASat,1,N/A,51191050
+HG01071,2,s3://human-pangenomics/working/HPRC/HG01071/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01071-maternal.bed,ASat,1,N/A,50196671
+HG01071,1,s3://human-pangenomics/working/HPRC/HG01071/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01071-paternal.bed,ASat,1,N/A,50817650
+HG01106,2,s3://human-pangenomics/working/HPRC/HG01106/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01106-maternal.bed,ASat,1,N/A,48433779
+HG01106,1,s3://human-pangenomics/working/HPRC/HG01106/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01106-paternal.bed,ASat,1,N/A,47176202
+HG01109,2,s3://human-pangenomics/working/HPRC_PLUS/HG01109/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01109-maternal.bed,ASat,1,N/A,49164014
+HG01109,1,s3://human-pangenomics/working/HPRC_PLUS/HG01109/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01109-paternal.bed,ASat,1,N/A,43497915
+HG01123,2,s3://human-pangenomics/working/HPRC/HG01123/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01123-maternal.bed,ASat,1,N/A,50286691
+HG01123,1,s3://human-pangenomics/working/HPRC/HG01123/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01123-paternal.bed,ASat,1,N/A,49046347
+HG01175,2,s3://human-pangenomics/working/HPRC/HG01175/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01175-maternal.bed,ASat,1,N/A,49426223
+HG01175,1,s3://human-pangenomics/working/HPRC/HG01175/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01175-paternal.bed,ASat,1,N/A,49925648
+HG01243,2,s3://human-pangenomics/working/HPRC_PLUS/HG01243/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01243-maternal.bed,ASat,1,N/A,50881072
+HG01243,1,s3://human-pangenomics/working/HPRC_PLUS/HG01243/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01243-paternal.bed,ASat,1,N/A,44064586
+HG01258,2,s3://human-pangenomics/working/HPRC/HG01258/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01258-maternal.bed,ASat,1,N/A,49995925
+HG01258,1,s3://human-pangenomics/working/HPRC/HG01258/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01258-paternal.bed,ASat,1,N/A,47087592
+HG01358,2,s3://human-pangenomics/working/HPRC/HG01358/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01358-maternal.bed,ASat,1,N/A,45153278
+HG01358,1,s3://human-pangenomics/working/HPRC/HG01358/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01358-paternal.bed,ASat,1,N/A,46955549
+HG01361,2,s3://human-pangenomics/working/HPRC/HG01361/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01361-maternal.bed,ASat,1,N/A,44636821
+HG01361,1,s3://human-pangenomics/working/HPRC/HG01361/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01361-paternal.bed,ASat,1,N/A,47172337
+HG01891,2,s3://human-pangenomics/working/HPRC/HG01891/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01891-maternal.bed,ASat,1,N/A,47084127
+HG01891,1,s3://human-pangenomics/working/HPRC/HG01891/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01891-paternal.bed,ASat,1,N/A,45720941
+HG01928,2,s3://human-pangenomics/working/HPRC/HG01928/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01928-maternal.bed,ASat,1,N/A,45410705
+HG01928,1,s3://human-pangenomics/working/HPRC/HG01928/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01928-paternal.bed,ASat,1,N/A,50184564
+HG01952,2,s3://human-pangenomics/working/HPRC/HG01952/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01952-maternal.bed,ASat,1,N/A,48944999
+HG01952,1,s3://human-pangenomics/working/HPRC/HG01952/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01952-paternal.bed,ASat,1,N/A,45844889
+HG01978,2,s3://human-pangenomics/working/HPRC/HG01978/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01978-maternal.bed,ASat,1,N/A,52985601
+HG01978,1,s3://human-pangenomics/working/HPRC/HG01978/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01978-paternal.bed,ASat,1,N/A,52284898
+HG02055,2,s3://human-pangenomics/working/HPRC_PLUS/HG02055/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02055-maternal.bed,ASat,1,N/A,45862415
+HG02055,1,s3://human-pangenomics/working/HPRC_PLUS/HG02055/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02055-paternal.bed,ASat,1,N/A,48829964
+HG02080,2,s3://human-pangenomics/working/HPRC_PLUS/HG02080/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02080-maternal.bed,ASat,1,N/A,49430867
+HG02080,1,s3://human-pangenomics/working/HPRC_PLUS/HG02080/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02080-paternal.bed,ASat,1,N/A,46447052
+HG02109,2,s3://human-pangenomics/working/HPRC_PLUS/HG02109/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02109-maternal.bed,ASat,1,N/A,42906796
+HG02109,1,s3://human-pangenomics/working/HPRC_PLUS/HG02109/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02109-paternal.bed,ASat,1,N/A,47904115
+HG02145,2,s3://human-pangenomics/working/HPRC_PLUS/HG02145/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02145-maternal.bed,ASat,1,N/A,47533974
+HG02145,1,s3://human-pangenomics/working/HPRC_PLUS/HG02145/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02145-paternal.bed,ASat,1,N/A,46883900
+HG02148,2,s3://human-pangenomics/working/HPRC/HG02148/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02148-maternal.bed,ASat,1,N/A,51628971
+HG02148,1,s3://human-pangenomics/working/HPRC/HG02148/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02148-paternal.bed,ASat,1,N/A,46484093
+HG02257,2,s3://human-pangenomics/working/HPRC/HG02257/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02257-maternal.bed,ASat,1,N/A,46353345
+HG02257,1,s3://human-pangenomics/working/HPRC/HG02257/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02257-paternal.bed,ASat,1,N/A,45087588
+HG02486,2,s3://human-pangenomics/working/HPRC/HG02486/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02486-maternal.bed,ASat,1,N/A,46777360
+HG02486,1,s3://human-pangenomics/working/HPRC/HG02486/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02486-paternal.bed,ASat,1,N/A,45794998
+HG02559,2,s3://human-pangenomics/working/HPRC/HG02559/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02559-maternal.bed,ASat,1,N/A,46378147
+HG02559,1,s3://human-pangenomics/working/HPRC/HG02559/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02559-paternal.bed,ASat,1,N/A,46092531
+HG02572,2,s3://human-pangenomics/working/HPRC/HG02572/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02572-maternal.bed,ASat,1,N/A,52192979
+HG02572,1,s3://human-pangenomics/working/HPRC/HG02572/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02572-paternal.bed,ASat,1,N/A,45988521
+HG02622,2,s3://human-pangenomics/working/HPRC/HG02622/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02622-maternal.bed,ASat,1,N/A,46290815
+HG02622,1,s3://human-pangenomics/working/HPRC/HG02622/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02622-paternal.bed,ASat,1,N/A,47435960
+HG02630,2,s3://human-pangenomics/working/HPRC/HG02630/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02630-maternal.bed,ASat,1,N/A,47718335
+HG02630,1,s3://human-pangenomics/working/HPRC/HG02630/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02630-paternal.bed,ASat,1,N/A,51708128
+HG02717,2,s3://human-pangenomics/working/HPRC/HG02717/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02717-maternal.bed,ASat,1,N/A,48304626
+HG02717,1,s3://human-pangenomics/working/HPRC/HG02717/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02717-paternal.bed,ASat,1,N/A,48691114
+HG02723,2,s3://human-pangenomics/working/HPRC_PLUS/HG02723/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02723-maternal.bed,ASat,1,N/A,45115030
+HG02723,1,s3://human-pangenomics/working/HPRC_PLUS/HG02723/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02723-paternal.bed,ASat,1,N/A,49700865
+HG02818,2,s3://human-pangenomics/working/HPRC_PLUS/HG02818/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02818-maternal.bed,ASat,1,N/A,47897466
+HG02818,1,s3://human-pangenomics/working/HPRC_PLUS/HG02818/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02818-paternal.bed,ASat,1,N/A,46784311
+HG02886,2,s3://human-pangenomics/working/HPRC/HG02886/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02886-maternal.bed,ASat,1,N/A,45287078
+HG02886,1,s3://human-pangenomics/working/HPRC/HG02886/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02886-paternal.bed,ASat,1,N/A,45414020
+HG03098,2,s3://human-pangenomics/working/HPRC_PLUS/HG03098/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03098-maternal.bed,ASat,1,N/A,49810990
+HG03098,1,s3://human-pangenomics/working/HPRC_PLUS/HG03098/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03098-paternal.bed,ASat,1,N/A,45848738
+HG03453,2,s3://human-pangenomics/working/HPRC/HG03453/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03453-maternal.bed,ASat,1,N/A,44914581
+HG03453,1,s3://human-pangenomics/working/HPRC/HG03453/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03453-paternal.bed,ASat,1,N/A,50928751
+HG03486,2,s3://human-pangenomics/working/HPRC_PLUS/HG03486/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03486-maternal.bed,ASat,1,N/A,49506362
+HG03486,1,s3://human-pangenomics/working/HPRC_PLUS/HG03486/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03486-paternal.bed,ASat,1,N/A,50931608
+HG03492,2,s3://human-pangenomics/working/HPRC_PLUS/HG03492/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03492-maternal.bed,ASat,1,N/A,48133232
+HG03492,1,s3://human-pangenomics/working/HPRC_PLUS/HG03492/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03492-paternal.bed,ASat,1,N/A,45610960
+HG03516,2,s3://human-pangenomics/working/HPRC/HG03516/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03516-maternal.bed,ASat,1,N/A,43821812
+HG03516,1,s3://human-pangenomics/working/HPRC/HG03516/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03516-paternal.bed,ASat,1,N/A,51832747
+HG03540,2,s3://human-pangenomics/working/HPRC/HG03540/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03540-maternal.bed,ASat,1,N/A,45096842
+HG03540,1,s3://human-pangenomics/working/HPRC/HG03540/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03540-paternal.bed,ASat,1,N/A,47758110
+HG03579,2,s3://human-pangenomics/working/HPRC/HG03579/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03579-maternal.bed,ASat,1,N/A,45602204
+HG03579,1,s3://human-pangenomics/working/HPRC/HG03579/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03579-paternal.bed,ASat,1,N/A,44863863
+NA18906,2,s3://human-pangenomics/working/HPRC_PLUS/NA18906/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-NA18906-maternal.bed,ASat,1,N/A,46958226
+NA18906,1,s3://human-pangenomics/working/HPRC_PLUS/NA18906/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-NA18906-paternal.bed,ASat,1,N/A,44237834
+NA19240,2,s3://human-pangenomics/working/HPRC_PLUS/NA19240/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-NA19240-maternal.bed,ASat,1,N/A,45716532
+NA19240,1,s3://human-pangenomics/working/HPRC_PLUS/NA19240/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-NA19240-paternal.bed,ASat,1,N/A,45236400
+NA20129,2,s3://human-pangenomics/working/HPRC_PLUS/NA20129/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-NA20129-maternal.bed,ASat,1,N/A,46593286
+NA20129,1,s3://human-pangenomics/working/HPRC_PLUS/NA20129/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-NA20129-paternal.bed,ASat,1,N/A,46467558
+NA21309,2,s3://human-pangenomics/working/HPRC_PLUS/NA21309/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-NA21309-maternal.bed,ASat,1,N/A,43547705
+NA21309,1,s3://human-pangenomics/working/HPRC_PLUS/NA21309/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-NA21309-paternal.bed,ASat,1,N/A,44926696
 GCA_000001405.15_GRCh38_no_alt_analysis_set,,s3://human-pangenomics/working/HPRC_PLUS/GRCh38/assemblies/year1_f1_assembly_v2_genbank/annotation/dna_brnn/GCA_000001405.15_GRCh38_no_alt_analysis_set.dna_brnn.bed,DNA_BRNN,1,N/A,97308
 HG002,2,s3://human-pangenomics/working/HPRC_PLUS/HG002/assemblies/year1_f1_assembly_v2_genbank/annotation/dna_brnn/HG002.maternal.f1_assembly_v2_genbank.dna_brnn.bed,DNA_BRNN,1,N/A,231598
 HG002,1,s3://human-pangenomics/working/HPRC_PLUS/HG002/assemblies/year1_f1_assembly_v2_genbank/annotation/dna_brnn/HG002.paternal.f1_assembly_v2_genbank.dna_brnn.bed,DNA_BRNN,1,N/A,222098
@@ -2732,468 +2732,468 @@ NA21144,1,s3://human-pangenomics/working/HPRC/NA21144/assemblies/release2/alignm
 NA21144,2,s3://human-pangenomics/working/HPRC/NA21144/assemblies/release2/alignments/winnowmap/GRCh38_no_alt/NA21144.GRCh38_no_alt.hap2.sorted.bam,Reference Mappings GRCh38,2,NA21144_hap2_hprc_r2_v1.0.1,2305623046
 NA21309,1,s3://human-pangenomics/working/HPRC_PLUS/NA21309/assemblies/release2/alignments/winnowmap/GRCh38_no_alt/NA21309.GRCh38_no_alt.hap1.sorted.bam,Reference Mappings GRCh38,2,NA21309_pat_hprc_r2_v1.0.1,2220974688
 NA21309,2,s3://human-pangenomics/working/HPRC_PLUS/NA21309/assemblies/release2/alignments/winnowmap/GRCh38_no_alt/NA21309.GRCh38_no_alt.hap2.sorted.bam,Reference Mappings GRCh38,2,NA21309_mat_hprc_r2_v1.0.1,2398387271
-HG01081,1,s3://human-pangenomics/working/HPRC/HG01081/assemblies/release2/annotation/cat/HG01081_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01081_pat_hprc_r2_v1.0.1,63192178
-HG02647,1,s3://human-pangenomics/working/HPRC/HG02647/assemblies/release2/annotation/cat/HG02647_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02647_pat_hprc_r2_v1.0.1,61677723
-HG02622,1,s3://human-pangenomics/working/HPRC/HG02622/assemblies/release2/annotation/cat/HG02622_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02622_pat_hprc_r2_v1.0.1,63669289
-HG01361,2,s3://human-pangenomics/working/HPRC/HG01361/assemblies/release2/annotation/cat/HG01361_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01361_mat_hprc_r2_v1.0.1,63220161
-HG00735,1,s3://human-pangenomics/working/HPRC/HG00735/assemblies/release2/annotation/cat/HG00735_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00735_pat_hprc_r2_v1.0.1,63259597
-HG00321,2,s3://human-pangenomics/working/HPRC/HG00321/assemblies/release2/annotation/cat/HG00321_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00321_hap2_hprc_r2_v1.0.1,63502215
-HG03139,1,s3://human-pangenomics/working/HPRC/HG03139/assemblies/release2/annotation/cat/HG03139_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03139_hap1_hprc_r2_v1.0.1,61961416
-NA20346,1,s3://human-pangenomics/working/HPRC/NA20346/assemblies/release2/annotation/cat/NA20346_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA20346_hap1_hprc_r2_v1.0.1,61737082
-HG01960,2,s3://human-pangenomics/working/HPRC/HG01960/assemblies/release2/annotation/cat/HG01960_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01960_mat_hprc_r2_v1.0.1,63375489
-HG03453,2,s3://human-pangenomics/working/HPRC/HG03453/assemblies/release2/annotation/cat/HG03453_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03453_mat_hprc_r2_v1.0.1,63894915
-HG02165,2,s3://human-pangenomics/working/HPRC/HG02165/assemblies/release2/annotation/cat/HG02165_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02165_hap2_hprc_r2_v1.0.1,63216116
-HG02738,1,s3://human-pangenomics/working/HPRC/HG02738/assemblies/release2/annotation/cat/HG02738_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02738_pat_hprc_r2_v1.0.1,61786449
-HG02055,2,s3://human-pangenomics/working/HPRC_PLUS/HG02055/assemblies/release2/annotation/cat/HG02055_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02055_mat_hprc_r2_v1.0.1,61680629
-HG01261,2,s3://human-pangenomics/working/HPRC/HG01261/assemblies/release2/annotation/cat/HG01261_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01261_mat_hprc_r2_v1.0.1,63198860
-HG03742,1,s3://human-pangenomics/working/HPRC/HG03742/assemblies/release2/annotation/cat/HG03742_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03742_hap1_hprc_r2_v1.0.1,61700292
-NA19700,2,s3://human-pangenomics/working/HPRC/NA19700/assemblies/release2/annotation/cat/NA19700_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA19700_hap2_hprc_r2_v1.0.1,63483121
-NA18976,2,s3://human-pangenomics/working/HPRC/NA18976/assemblies/release2/annotation/cat/NA18976_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18976_hap2_hprc_r2_v1.0.1,63278870
-HG01981,2,s3://human-pangenomics/working/HPRC/HG01981/assemblies/release2/annotation/cat/HG01981_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01981_mat_hprc_r2_v1.0.1,63505629
-NA18967,2,s3://human-pangenomics/working/HPP/NA18967/assemblies/release2/annotation/cat/NA18967_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18967_hap2_hprc_r2_v1.0.1,63122804
-NA19036,1,s3://human-pangenomics/working/HPRC/NA19036/assemblies/release2/annotation/cat/NA19036_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA19036_hap1_hprc_r2_v1.0.1,63110428
-HG00329,1,s3://human-pangenomics/working/HPRC/HG00329/assemblies/release2/annotation/cat/HG00329_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00329_hap1_hprc_r2_v1.0.1,61534761
-NA18565,2,s3://human-pangenomics/working/HPRC/NA18565/assemblies/release2/annotation/cat/NA18565_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18565_hap2_hprc_r2_v1.0.1,63278520
-NA20503,1,s3://human-pangenomics/working/HPRC/NA20503/assemblies/release2/annotation/cat/NA20503_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA20503_hap1_hprc_r2_v1.0.1,63058446
-HG005,2,s3://human-pangenomics/working/HPRC_PLUS/HG005/assemblies/release2/annotation/cat/HG005_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG005_mat_hprc_r2_v1.0.1,61498805
-HG02055,1,s3://human-pangenomics/working/HPRC_PLUS/HG02055/assemblies/release2/annotation/cat/HG02055_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02055_pat_hprc_r2_v1.0.1,60203968
-HG02293,1,s3://human-pangenomics/working/HPRC/HG02293/assemblies/release2/annotation/cat/HG02293_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02293_pat_hprc_r2_v1.0.1,63494112
-NA18565,1,s3://human-pangenomics/working/HPRC/NA18565/assemblies/release2/annotation/cat/NA18565_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18565_hap1_hprc_r2_v1.0.1,63161912
-HG03654,1,s3://human-pangenomics/working/HPRC/HG03654/assemblies/release2/annotation/cat/HG03654_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03654_pat_hprc_r2_v1.0.1,61818896
-HG03516,1,s3://human-pangenomics/working/HPRC/HG03516/assemblies/release2/annotation/cat/HG03516_pat_hprc_r2_v1.1.0_cat_v1.1.gff3.gz,CAT Genes,2,HG03516_pat_hprc_r2_v1.1.0,63836862
-HG00609,2,s3://human-pangenomics/working/HPRC/HG00609/assemblies/release2/annotation/cat/HG00609_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00609_mat_hprc_r2_v1.0.1,63419739
-HG02080,2,s3://human-pangenomics/working/HPRC_PLUS/HG02080/assemblies/release2/annotation/cat/HG02080_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02080_mat_hprc_r2_v1.0.1,61759944
-HG00558,2,s3://human-pangenomics/working/HPRC/HG00558/assemblies/release2/annotation/cat/HG00558_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00558_mat_hprc_r2_v1.0.1,63224297
-HG02841,2,s3://human-pangenomics/working/HPRC/HG02841/assemblies/release2/annotation/cat/HG02841_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02841_mat_hprc_r2_v1.0.1,63248850
-HG02523,2,s3://human-pangenomics/working/HPRC/HG02523/assemblies/release2/annotation/cat/HG02523_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02523_mat_hprc_r2_v1.0.1,63045714
-HG00658,1,s3://human-pangenomics/working/HPRC/HG00658/assemblies/release2/annotation/cat/HG00658_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00658_pat_hprc_r2_v1.0.1,61722547
-HG02040,2,s3://human-pangenomics/working/HPRC/HG02040/assemblies/release2/annotation/cat/HG02040_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02040_hap2_hprc_r2_v1.0.1,63680721
-HG02004,1,s3://human-pangenomics/working/HPRC/HG02004/assemblies/release2/annotation/cat/HG02004_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02004_pat_hprc_r2_v1.0.1,63232837
-HG01243,1,s3://human-pangenomics/working/HPRC_PLUS/HG01243/assemblies/release2/annotation/cat/HG01243_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01243_pat_hprc_r2_v1.0.1,60054461
-NA20870,2,s3://human-pangenomics/working/HPRC/NA20870/assemblies/release2/annotation/cat/NA20870_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA20870_hap2_hprc_r2_v1.0.1,63771404
-HG01943,1,s3://human-pangenomics/working/HPRC/HG01943/assemblies/release2/annotation/cat/HG01943_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01943_pat_hprc_r2_v1.0.1,61740336
-HG03453,1,s3://human-pangenomics/working/HPRC/HG03453/assemblies/release2/annotation/cat/HG03453_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03453_pat_hprc_r2_v1.0.1,63937648
-HG03050,1,s3://human-pangenomics/working/HPRC/HG03050/assemblies/release2/annotation/cat/HG03050_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03050_pat_hprc_r2_v1.0.1,60095871
-HG02071,1,s3://human-pangenomics/working/HPRC/HG02071/assemblies/release2/annotation/cat/HG02071_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02071_pat_hprc_r2_v1.0.1,61649802
-HG00140,1,s3://human-pangenomics/working/HPRC/HG00140/assemblies/release2/annotation/cat/HG00140_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00140_hap1_hprc_r2_v1.0.1,61666996
-HG01784,2,s3://human-pangenomics/working/HPRC/HG01784/assemblies/release2/annotation/cat/HG01784_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01784_hap2_hprc_r2_v1.0.1,63484551
-HG04157,2,s3://human-pangenomics/working/HPRC/HG04157/assemblies/release2/annotation/cat/HG04157_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG04157_mat_hprc_r2_v1.0.1,63292100
-HG03540,1,s3://human-pangenomics/working/HPRC/HG03540/assemblies/release2/annotation/cat/HG03540_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03540_pat_hprc_r2_v1.0.1,63709318
-HG01258,2,s3://human-pangenomics/working/HPRC/HG01258/assemblies/release2/annotation/cat/HG01258_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01258_mat_hprc_r2_v1.0.1,63356383
-NA20809,1,s3://human-pangenomics/working/HPRC/NA20809/assemblies/release2/annotation/cat/NA20809_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA20809_hap1_hprc_r2_v1.0.1,61707624
-HG02109,2,s3://human-pangenomics/working/HPRC_PLUS/HG02109/assemblies/release2/annotation/cat/HG02109_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02109_mat_hprc_r2_v1.0.1,61610857
-HG04115,2,s3://human-pangenomics/working/HPRC/HG04115/assemblies/release2/annotation/cat/HG04115_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG04115_mat_hprc_r2_v1.0.1,63402647
-NA21093,1,s3://human-pangenomics/working/HPRC/NA21093/assemblies/release2/annotation/cat/NA21093_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA21093_hap1_hprc_r2_v1.0.1,61611613
-HG02004,2,s3://human-pangenomics/working/HPRC/HG02004/assemblies/release2/annotation/cat/HG02004_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02004_mat_hprc_r2_v1.0.1,63170284
-HG00133,2,s3://human-pangenomics/working/HPRC/HG00133/assemblies/release2/annotation/cat/HG00133_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00133_hap2_hprc_r2_v1.0.1,63394214
-HG01784,1,s3://human-pangenomics/working/HPRC/HG01784/assemblies/release2/annotation/cat/HG01784_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01784_hap1_hprc_r2_v1.0.1,63611831
-HG02132,1,s3://human-pangenomics/working/HPRC/HG02132/assemblies/release2/annotation/cat/HG02132_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02132_pat_hprc_r2_v1.0.1,61505709
-HG01952,2,s3://human-pangenomics/working/HPRC/HG01952/assemblies/release2/annotation/cat/HG01952_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01952_mat_hprc_r2_v1.0.1,63281910
-HG00639,2,s3://human-pangenomics/working/HPRC/HG00639/assemblies/release2/annotation/cat/HG00639_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00639_mat_hprc_r2_v1.0.1,63474013
-HG03471,1,s3://human-pangenomics/working/HPRC/HG03471/assemblies/release2/annotation/cat/HG03471_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03471_hap1_hprc_r2_v1.0.1,60193789
-NA19776,2,s3://human-pangenomics/working/HPRC/NA19776/assemblies/release2/annotation/cat/NA19776_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA19776_hap2_hprc_r2_v1.0.1,63299425
-HG01175,1,s3://human-pangenomics/working/HPRC/HG01175/assemblies/release2/annotation/cat/HG01175_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01175_pat_hprc_r2_v1.0.1,63156984
-HG02735,2,s3://human-pangenomics/working/HPRC/HG02735/assemblies/release2/annotation/cat/HG02735_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02735_mat_hprc_r2_v1.0.1,63434856
-HG02698,2,s3://human-pangenomics/working/HPRC/HG02698/assemblies/release2/annotation/cat/HG02698_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02698_mat_hprc_r2_v1.0.1,63415711
-HG02257,2,s3://human-pangenomics/working/HPRC/HG02257/assemblies/release2/annotation/cat/HG02257_mat_hprc_r2_v1.1.0_cat_v1.1.gff3.gz,CAT Genes,2,HG02257_mat_hprc_r2_v1.1.0,63752966
-HG03834,2,s3://human-pangenomics/working/HPRC/HG03834/assemblies/release2/annotation/cat/HG03834_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03834_mat_hprc_r2_v1.0.1,63433476
-HG01109,1,s3://human-pangenomics/working/HPRC_PLUS/HG01109/assemblies/release2/annotation/cat/HG01109_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01109_pat_hprc_r2_v1.0.1,60129648
-NA18945,2,s3://human-pangenomics/working/HPP/NA18945/assemblies/release2/annotation/cat/NA18945_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18945_hap2_hprc_r2_v1.0.1,61717412
-NA18976,1,s3://human-pangenomics/working/HPRC/NA18976/assemblies/release2/annotation/cat/NA18976_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18976_hap1_hprc_r2_v1.0.1,63301390
-HG03225,2,s3://human-pangenomics/working/HPRC/HG03225/assemblies/release2/annotation/cat/HG03225_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03225_hap2_hprc_r2_v1.0.1,63867210
-NA20762,2,s3://human-pangenomics/working/HPRC/NA20762/assemblies/release2/annotation/cat/NA20762_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA20762_hap2_hprc_r2_v1.0.1,63252494
-HG02040,1,s3://human-pangenomics/working/HPRC/HG02040/assemblies/release2/annotation/cat/HG02040_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02040_hap1_hprc_r2_v1.0.1,61853903
-NA20870,1,s3://human-pangenomics/working/HPRC/NA20870/assemblies/release2/annotation/cat/NA20870_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA20870_hap1_hprc_r2_v1.0.1,61703736
-HG03017,1,s3://human-pangenomics/working/HPRC/HG03017/assemblies/release2/annotation/cat/HG03017_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03017_pat_hprc_r2_v1.0.1,61494183
-NA18974,1,s3://human-pangenomics/working/HPRC/NA18974/assemblies/release2/annotation/cat/NA18974_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18974_hap1_hprc_r2_v1.0.1,61857384
-HG00438,2,s3://human-pangenomics/working/HPRC/HG00438/assemblies/release2/annotation/cat/HG00438_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00438_mat_hprc_r2_v1.0.1,63387207
-HG00323,1,s3://human-pangenomics/working/HPRC/HG00323/assemblies/release2/annotation/cat/HG00323_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00323_hap1_hprc_r2_v1.0.1,63552805
-NA21110,2,s3://human-pangenomics/working/HPRC/NA21110/assemblies/release2/annotation/cat/NA21110_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA21110_hap2_hprc_r2_v1.0.1,63637489
-HG02080,1,s3://human-pangenomics/working/HPRC_PLUS/HG02080/assemblies/release2/annotation/cat/HG02080_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02080_pat_hprc_r2_v1.0.1,61782782
-HG00290,1,s3://human-pangenomics/working/HPRC/HG00290/assemblies/release2/annotation/cat/HG00290_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00290_hap1_hprc_r2_v1.0.1,61806959
-NA20806,2,s3://human-pangenomics/working/HPRC/NA20806/assemblies/release2/annotation/cat/NA20806_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA20806_hap2_hprc_r2_v1.0.1,63333317
-HG01981,1,s3://human-pangenomics/working/HPRC/HG01981/assemblies/release2/annotation/cat/HG01981_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01981_pat_hprc_r2_v1.0.1,63556623
-HG01106,2,s3://human-pangenomics/working/HPRC/HG01106/assemblies/release2/annotation/cat/HG01106_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01106_mat_hprc_r2_v1.0.1,63160059
-HG00253,1,s3://human-pangenomics/working/HPRC/HG00253/assemblies/release2/annotation/cat/HG00253_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00253_hap1_hprc_r2_v1.0.1,63207930
-HG04157,1,s3://human-pangenomics/working/HPRC/HG04157/assemblies/release2/annotation/cat/HG04157_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG04157_pat_hprc_r2_v1.0.1,61839132
-HG02723,1,s3://human-pangenomics/working/HPRC_PLUS/HG02723/assemblies/release2/annotation/cat/HG02723_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02723_pat_hprc_r2_v1.0.1,61655152
-HG04115,1,s3://human-pangenomics/working/HPRC/HG04115/assemblies/release2/annotation/cat/HG04115_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG04115_pat_hprc_r2_v1.0.1,61740721
-NA20129,2,s3://human-pangenomics/working/HPRC_PLUS/NA20129/assemblies/release2/annotation/cat/NA20129_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA20129_mat_hprc_r2_v1.0.1,61638409
-NA18959,2,s3://human-pangenomics/working/HPP/NA18959/assemblies/release2/annotation/cat/NA18959_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18959_hap2_hprc_r2_v1.0.1,61956850
-HG02293,2,s3://human-pangenomics/working/HPRC/HG02293/assemblies/release2/annotation/cat/HG02293_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02293_mat_hprc_r2_v1.0.1,63231151
-HG01346,2,s3://human-pangenomics/working/HPRC/HG01346/assemblies/release2/annotation/cat/HG01346_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01346_mat_hprc_r2_v1.0.1,63630022
-NA20809,2,s3://human-pangenomics/working/HPRC/NA20809/assemblies/release2/annotation/cat/NA20809_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA20809_hap2_hprc_r2_v1.0.1,63227987
-HG01975,1,s3://human-pangenomics/working/HPRC/HG01975/assemblies/release2/annotation/cat/HG01975_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01975_pat_hprc_r2_v1.0.1,63657132
-NA20282,2,s3://human-pangenomics/working/HPRC/NA20282/assemblies/release2/annotation/cat/NA20282_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA20282_hap2_hprc_r2_v1.0.1,62909570
-NA18983,2,s3://human-pangenomics/working/HPRC/NA18983/assemblies/release2/annotation/cat/NA18983_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18983_hap2_hprc_r2_v1.0.1,63350292
-NA21110,1,s3://human-pangenomics/working/HPRC/NA21110/assemblies/release2/annotation/cat/NA21110_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA21110_hap1_hprc_r2_v1.0.1,63692680
-HG03270,2,s3://human-pangenomics/working/HPRC/HG03270/assemblies/release2/annotation/cat/HG03270_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03270_hap2_hprc_r2_v1.0.1,63351564
-NA20799,1,s3://human-pangenomics/working/HPRC/NA20799/assemblies/release2/annotation/cat/NA20799_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA20799_hap1_hprc_r2_v1.0.1,63673603
-HG01978,2,s3://human-pangenomics/working/HPRC/HG01978/assemblies/release2/annotation/cat/HG01978_mat_hprc_r2_v1.1.0_cat_v1.1.gff3.gz,CAT Genes,2,HG01978_mat_hprc_r2_v1.1.0,63180407
-HG02486,2,s3://human-pangenomics/working/HPRC/HG02486/assemblies/release2/annotation/cat/HG02486_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02486_mat_hprc_r2_v1.0.1,61632149
-HG03579,2,s3://human-pangenomics/working/HPRC/HG03579/assemblies/release2/annotation/cat/HG03579_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03579_mat_hprc_r2_v1.0.1,63269131
-NA18970,1,s3://human-pangenomics/working/HPP/NA18970/assemblies/release2/annotation/cat/NA18970_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18970_hap1_hprc_r2_v1.0.1,61494294
-HG00673,1,s3://human-pangenomics/working/HPRC/HG00673/assemblies/release2/annotation/cat/HG00673_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00673_pat_hprc_r2_v1.0.1,61681249
-HG00232,1,s3://human-pangenomics/working/HPRC/HG00232/assemblies/release2/annotation/cat/HG00232_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00232_hap1_hprc_r2_v1.0.1,63488149
-HG02886,2,s3://human-pangenomics/working/HPRC/HG02886/assemblies/release2/annotation/cat/HG02886_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02886_mat_hprc_r2_v1.0.1,63732887
-HG01940,1,s3://human-pangenomics/working/HPRC/HG01940/assemblies/release2/annotation/cat/HG01940_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01940_pat_hprc_r2_v1.0.1,63352737
-HG03470,1,s3://human-pangenomics/working/HPRC/HG03470/assemblies/release2/annotation/cat/HG03470_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03470_hap1_hprc_r2_v1.0.1,63558563
-NA18971,2,s3://human-pangenomics/working/HPRC/NA18971/assemblies/release2/annotation/cat/NA18971_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18971_hap2_hprc_r2_v1.0.1,63120773
-HG01167,1,s3://human-pangenomics/working/HPRC/HG01167/assemblies/release2/annotation/cat/HG01167_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01167_hap1_hprc_r2_v1.0.1,61764575
-HG02155,1,s3://human-pangenomics/working/HPRC/HG02155/assemblies/release2/annotation/cat/HG02155_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02155_hap1_hprc_r2_v1.0.1,63427667
-NA19240,1,s3://human-pangenomics/working/HPRC_PLUS/NA19240/assemblies/release2/annotation/cat/NA19240_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA19240_pat_hprc_r2_v1.0.1,61656123
-NA19443,1,s3://human-pangenomics/working/HPRC/NA19443/assemblies/release2/annotation/cat/NA19443_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA19443_hap1_hprc_r2_v1.0.1,61695150
-HG01074,1,s3://human-pangenomics/working/HPRC/HG01074/assemblies/release2/annotation/cat/HG01074_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01074_pat_hprc_r2_v1.0.1,61370357
-HG02178,1,s3://human-pangenomics/working/HPRC/HG02178/assemblies/release2/annotation/cat/HG02178_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02178_hap1_hprc_r2_v1.0.1,63260191
-HG00706,2,s3://human-pangenomics/working/HPRC/HG00706/assemblies/release2/annotation/cat/HG00706_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00706_mat_hprc_r2_v1.0.1,63382005
-HG01261,1,s3://human-pangenomics/working/HPRC/HG01261/assemblies/release2/annotation/cat/HG01261_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01261_pat_hprc_r2_v1.0.1,61564073
-HG02723,2,s3://human-pangenomics/working/HPRC_PLUS/HG02723/assemblies/release2/annotation/cat/HG02723_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02723_mat_hprc_r2_v1.0.1,61666305
-HG02976,2,s3://human-pangenomics/working/HPRC/HG02976/assemblies/release2/annotation/cat/HG02976_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02976_hap2_hprc_r2_v1.0.1,64237688
-HG01978,1,s3://human-pangenomics/working/HPRC/HG01978/assemblies/release2/annotation/cat/HG01978_pat_hprc_r2_v1.1.0_cat_v1.1.gff3.gz,CAT Genes,2,HG01978_pat_hprc_r2_v1.1.0,63220541
-NA20850,2,s3://human-pangenomics/working/HPRC/NA20850/assemblies/release2/annotation/cat/NA20850_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA20850_hap2_hprc_r2_v1.0.1,63218750
-HG02074,2,s3://human-pangenomics/working/HPRC/HG02074/assemblies/release2/annotation/cat/HG02074_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02074_mat_hprc_r2_v1.0.1,63360200
-HG02391,1,s3://human-pangenomics/working/HPRC/HG02391/assemblies/release2/annotation/cat/HG02391_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02391_hap1_hprc_r2_v1.0.1,61999110
-HG02514,2,s3://human-pangenomics/working/HPRC/HG02514/assemblies/release2/annotation/cat/HG02514_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02514_mat_hprc_r2_v1.0.1,63428731
-HG02717,2,s3://human-pangenomics/working/HPRC/HG02717/assemblies/release2/annotation/cat/HG02717_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02717_mat_hprc_r2_v1.0.1,63562608
-HG01884,2,s3://human-pangenomics/working/HPRC/HG01884/assemblies/release2/annotation/cat/HG01884_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01884_mat_hprc_r2_v1.0.1,63151899
-HG02129,2,s3://human-pangenomics/working/HPRC/HG02129/assemblies/release2/annotation/cat/HG02129_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02129_mat_hprc_r2_v1.0.1,63559942
-NA20503,2,s3://human-pangenomics/working/HPRC/NA20503/assemblies/release2/annotation/cat/NA20503_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA20503_hap2_hprc_r2_v1.0.1,63142336
-HG03710,2,s3://human-pangenomics/working/HPRC/HG03710/assemblies/release2/annotation/cat/HG03710_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03710_mat_hprc_r2_v1.0.1,63375501
-HG01891,2,s3://human-pangenomics/working/HPRC/HG01891/assemblies/release2/annotation/cat/HG01891_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01891_mat_hprc_r2_v1.0.1,63761469
-NA19036,2,s3://human-pangenomics/working/HPRC/NA19036/assemblies/release2/annotation/cat/NA19036_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA19036_hap2_hprc_r2_v1.0.1,63251303
-HG01255,1,s3://human-pangenomics/working/HPRC/HG01255/assemblies/release2/annotation/cat/HG01255_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01255_pat_hprc_r2_v1.0.1,61422126
-HG00323,2,s3://human-pangenomics/working/HPRC/HG00323/assemblies/release2/annotation/cat/HG00323_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00323_hap2_hprc_r2_v1.0.1,63410371
-HG01081,2,s3://human-pangenomics/working/HPRC/HG01081/assemblies/release2/annotation/cat/HG01081_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01081_mat_hprc_r2_v1.0.1,63328424
-HG01884,1,s3://human-pangenomics/working/HPRC/HG01884/assemblies/release2/annotation/cat/HG01884_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01884_pat_hprc_r2_v1.0.1,63320260
-NA20762,1,s3://human-pangenomics/working/HPRC/NA20762/assemblies/release2/annotation/cat/NA20762_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA20762_hap1_hprc_r2_v1.0.1,60853437
-NA19338,1,s3://human-pangenomics/working/HPRC/NA19338/assemblies/release2/annotation/cat/NA19338_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA19338_hap1_hprc_r2_v1.0.1,63687421
-HG04187,2,s3://human-pangenomics/working/HPRC/HG04187/assemblies/release2/annotation/cat/HG04187_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG04187_mat_hprc_r2_v1.0.1,63332226
-HG02300,1,s3://human-pangenomics/working/HPRC/HG02300/assemblies/release2/annotation/cat/HG02300_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02300_pat_hprc_r2_v1.0.1,63417136
-HG03688,1,s3://human-pangenomics/working/HPRC/HG03688/assemblies/release2/annotation/cat/HG03688_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03688_pat_hprc_r2_v1.0.1,61409584
-NA18620,1,s3://human-pangenomics/working/HPRC/NA18620/assemblies/release2/annotation/cat/NA18620_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18620_hap1_hprc_r2_v1.0.1,61872141
-HG02178,2,s3://human-pangenomics/working/HPRC/HG02178/assemblies/release2/annotation/cat/HG02178_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02178_hap2_hprc_r2_v1.0.1,63582749
-HG04204,1,s3://human-pangenomics/working/HPRC/HG04204/assemblies/release2/annotation/cat/HG04204_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG04204_pat_hprc_r2_v1.0.1,61592527
-HG00272,1,s3://human-pangenomics/working/HPRC/HG00272/assemblies/release2/annotation/cat/HG00272_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00272_hap1_hprc_r2_v1.0.1,63286590
-HG02145,2,s3://human-pangenomics/working/HPRC_PLUS/HG02145/assemblies/release2/annotation/cat/HG02145_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02145_mat_hprc_r2_v1.0.1,61702419
-NA18940,1,s3://human-pangenomics/working/HPP/NA18940/assemblies/release2/annotation/cat/NA18940_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18940_hap1_hprc_r2_v1.0.1,59816005
-NA19087,1,s3://human-pangenomics/working/HPRC/NA19087/assemblies/release2/annotation/cat/NA19087_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA19087_hap1_hprc_r2_v1.0.1,63647871
-HG03688,2,s3://human-pangenomics/working/HPRC/HG03688/assemblies/release2/annotation/cat/HG03688_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03688_mat_hprc_r2_v1.0.1,63392860
-NA18940,2,s3://human-pangenomics/working/HPP/NA18940/assemblies/release2/annotation/cat/NA18940_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18940_hap2_hprc_r2_v1.0.1,60620202
-HG00741,2,s3://human-pangenomics/working/HPRC/HG00741/assemblies/release2/annotation/cat/HG00741_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00741_mat_hprc_r2_v1.0.1,63157465
-HG00320,1,s3://human-pangenomics/working/HPRC/HG00320/assemblies/release2/annotation/cat/HG00320_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00320_hap1_hprc_r2_v1.0.1,63366071
-HG00408,2,s3://human-pangenomics/working/HPRC/HG00408/assemblies/release2/annotation/cat/HG00408_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00408_mat_hprc_r2_v1.0.1,63488237
-HG03098,2,s3://human-pangenomics/working/HPRC_PLUS/HG03098/assemblies/release2/annotation/cat/HG03098_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03098_mat_hprc_r2_v1.0.1,61815130
-HG03195,2,s3://human-pangenomics/working/HPRC/HG03195/assemblies/release2/annotation/cat/HG03195_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03195_hap2_hprc_r2_v1.0.1,63544909
-NA20827,1,s3://human-pangenomics/working/HPRC/NA20827/assemblies/release2/annotation/cat/NA20827_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA20827_hap1_hprc_r2_v1.0.1,61298076
-HG00642,1,s3://human-pangenomics/working/HPRC/HG00642/assemblies/release2/annotation/cat/HG00642_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00642_pat_hprc_r2_v1.0.1,61910603
-HG00320,2,s3://human-pangenomics/working/HPRC/HG00320/assemblies/release2/annotation/cat/HG00320_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00320_hap2_hprc_r2_v1.0.1,63269454
-HG00126,1,s3://human-pangenomics/working/HPRC/HG00126/assemblies/release2/annotation/cat/HG00126_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00126_hap1_hprc_r2_v1.0.1,61750437
-HG02523,1,s3://human-pangenomics/working/HPRC/HG02523/assemblies/release2/annotation/cat/HG02523_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02523_pat_hprc_r2_v1.0.1,63258294
-HG00321,1,s3://human-pangenomics/working/HPRC/HG00321/assemblies/release2/annotation/cat/HG00321_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00321_hap1_hprc_r2_v1.0.1,61654608
-HG01150,2,s3://human-pangenomics/working/HPRC/HG01150/assemblies/release2/annotation/cat/HG01150_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01150_mat_hprc_r2_v1.0.1,63339348
-HG00642,2,s3://human-pangenomics/working/HPRC/HG00642/assemblies/release2/annotation/cat/HG00642_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00642_mat_hprc_r2_v1.0.1,63328853
-HG02735,1,s3://human-pangenomics/working/HPRC/HG02735/assemblies/release2/annotation/cat/HG02735_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02735_pat_hprc_r2_v1.0.1,61507079
-HG00673,2,s3://human-pangenomics/working/HPRC/HG00673/assemblies/release2/annotation/cat/HG00673_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00673_mat_hprc_r2_v1.0.1,63076369
-HG03050,2,s3://human-pangenomics/working/HPRC/HG03050/assemblies/release2/annotation/cat/HG03050_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03050_mat_hprc_r2_v1.0.1,61610691
-NA19700,1,s3://human-pangenomics/working/HPRC/NA19700/assemblies/release2/annotation/cat/NA19700_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA19700_hap1_hprc_r2_v1.0.1,61954528
-HG00621,1,s3://human-pangenomics/working/HPRC/HG00621/assemblies/release2/annotation/cat/HG00621_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00621_pat_hprc_r2_v1.0.1,61537972
-HG04199,2,s3://human-pangenomics/working/HPRC/HG04199/assemblies/release2/annotation/cat/HG04199_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG04199_mat_hprc_r2_v1.0.1,63378943
-HG01928,1,s3://human-pangenomics/working/HPRC/HG01928/assemblies/release2/annotation/cat/HG01928_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01928_pat_hprc_r2_v1.0.1,61564614
-HG03521,2,s3://human-pangenomics/working/HPRC/HG03521/assemblies/release2/annotation/cat/HG03521_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03521_hap2_hprc_r2_v1.0.1,63732083
-HG02155,2,s3://human-pangenomics/working/HPRC/HG02155/assemblies/release2/annotation/cat/HG02155_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02155_hap2_hprc_r2_v1.0.1,63488337
-NA18982,1,s3://human-pangenomics/working/HPP/NA18982/assemblies/release2/annotation/cat/NA18982_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18982_hap1_hprc_r2_v1.0.1,60013701
-HG00423,1,s3://human-pangenomics/working/HPRC/HG00423/assemblies/release2/annotation/cat/HG00423_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00423_pat_hprc_r2_v1.0.1,63097834
-HG01891,1,s3://human-pangenomics/working/HPRC/HG01891/assemblies/release2/annotation/cat/HG01891_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01891_pat_hprc_r2_v1.0.1,63622756
-HG02841,1,s3://human-pangenomics/working/HPRC/HG02841/assemblies/release2/annotation/cat/HG02841_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02841_pat_hprc_r2_v1.0.1,63372201
-HG00544,1,s3://human-pangenomics/working/HPRC/HG00544/assemblies/release2/annotation/cat/HG00544_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00544_pat_hprc_r2_v1.0.1,63098268
-HG01496,2,s3://human-pangenomics/working/HPRC/HG01496/assemblies/release2/annotation/cat/HG01496_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01496_mat_hprc_r2_v1.0.1,63358176
-HG00329,2,s3://human-pangenomics/working/HPRC/HG00329/assemblies/release2/annotation/cat/HG00329_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00329_hap2_hprc_r2_v1.0.1,63452156
-NA18952,1,s3://human-pangenomics/working/HPRC/NA18952/assemblies/release2/annotation/cat/NA18952_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18952_hap1_hprc_r2_v1.0.1,61805970
-HG00272,2,s3://human-pangenomics/working/HPRC/HG00272/assemblies/release2/annotation/cat/HG00272_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00272_hap2_hprc_r2_v1.0.1,63362113
-NA20282,1,s3://human-pangenomics/working/HPRC/NA20282/assemblies/release2/annotation/cat/NA20282_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA20282_hap1_hprc_r2_v1.0.1,63271704
-HG00232,2,s3://human-pangenomics/working/HPRC/HG00232/assemblies/release2/annotation/cat/HG00232_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00232_hap2_hprc_r2_v1.0.1,63477152
-HG02071,2,s3://human-pangenomics/working/HPRC/HG02071/assemblies/release2/annotation/cat/HG02071_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02071_mat_hprc_r2_v1.0.1,63520856
-NA18906,1,s3://human-pangenomics/working/HPRC_PLUS/NA18906/assemblies/release2/annotation/cat/NA18906_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18906_pat_hprc_r2_v1.0.1,61826973
-HG02630,1,s3://human-pangenomics/working/HPRC/HG02630/assemblies/release2/annotation/cat/HG02630_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02630_pat_hprc_r2_v1.0.1,63456893
-NA18948,2,s3://human-pangenomics/working/HPP/NA18948/assemblies/release2/annotation/cat/NA18948_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18948_hap2_hprc_r2_v1.0.1,61185054
-NA19682,1,s3://human-pangenomics/working/HPRC/NA19682/assemblies/release2/annotation/cat/NA19682_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA19682_hap1_hprc_r2_v1.0.1,61442555
-HG02083,1,s3://human-pangenomics/working/HPRC/HG02083/assemblies/release2/annotation/cat/HG02083_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02083_pat_hprc_r2_v1.0.1,61796802
-HG02258,1,s3://human-pangenomics/working/HPRC/HG02258/assemblies/release2/annotation/cat/HG02258_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02258_pat_hprc_r2_v1.0.1,61914895
-HG00344,1,s3://human-pangenomics/working/HPRC/HG00344/assemblies/release2/annotation/cat/HG00344_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00344_hap1_hprc_r2_v1.0.1,63352492
-NA19185,1,s3://human-pangenomics/working/HPRC/NA19185/assemblies/release2/annotation/cat/NA19185_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA19185_hap1_hprc_r2_v1.0.1,63295466
-HG01255,2,s3://human-pangenomics/working/HPRC/HG01255/assemblies/release2/annotation/cat/HG01255_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01255_mat_hprc_r2_v1.0.1,63215295
-HG01123,2,s3://human-pangenomics/working/HPRC/HG01123/assemblies/release2/annotation/cat/HG01123_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01123_mat_hprc_r2_v1.0.1,61622019
-NA18943,2,s3://human-pangenomics/working/HPP/NA18943/assemblies/release2/annotation/cat/NA18943_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18943_hap2_hprc_r2_v1.0.1,61747545
-HG01252,1,s3://human-pangenomics/working/HPRC/HG01252/assemblies/release2/annotation/cat/HG01252_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01252_pat_hprc_r2_v1.0.1,61673743
-HG02809,1,s3://human-pangenomics/working/HPRC/HG02809/assemblies/release2/annotation/cat/HG02809_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02809_pat_hprc_r2_v1.0.1,63448811
-NA18879,1,s3://human-pangenomics/working/HPRC/NA18879/assemblies/release2/annotation/cat/NA18879_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18879_hap1_hprc_r2_v1.0.1,61451365
-HG01969,2,s3://human-pangenomics/working/HPRC/HG01969/assemblies/release2/annotation/cat/HG01969_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01969_mat_hprc_r2_v1.0.1,63262782
-HG00438,1,s3://human-pangenomics/working/HPRC/HG00438/assemblies/release2/annotation/cat/HG00438_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00438_pat_hprc_r2_v1.0.1,63429945
-HG03369,1,s3://human-pangenomics/working/HPRC/HG03369/assemblies/release2/annotation/cat/HG03369_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03369_hap1_hprc_r2_v1.0.1,63287246
-NA21144,1,s3://human-pangenomics/working/HPRC/NA21144/assemblies/release2/annotation/cat/NA21144_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA21144_hap1_hprc_r2_v1.0.1,63330264
-NA18747,2,s3://human-pangenomics/working/HPRC/NA18747/assemblies/release2/annotation/cat/NA18747_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18747_hap2_hprc_r2_v1.0.1,63215798
-NA18959,1,s3://human-pangenomics/working/HPP/NA18959/assemblies/release2/annotation/cat/NA18959_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18959_hap1_hprc_r2_v1.0.1,59962282
-HG03239,2,s3://human-pangenomics/working/HPRC/HG03239/assemblies/release2/annotation/cat/HG03239_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03239_mat_hprc_r2_v1.0.1,63399749
-HG01530,1,s3://human-pangenomics/working/HPRC/HG01530/assemblies/release2/annotation/cat/HG01530_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01530_hap1_hprc_r2_v1.0.1,61785068
-HG03486,1,s3://human-pangenomics/working/HPRC_PLUS/HG03486/assemblies/release2/annotation/cat/HG03486_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03486_pat_hprc_r2_v1.0.1,61716237
-HG06807,1,s3://human-pangenomics/working/HPRC/HG06807/assemblies/release2/annotation/cat/HG06807_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG06807_pat_v1,60856025
-HG02717,1,s3://human-pangenomics/working/HPRC/HG02717/assemblies/release2/annotation/cat/HG02717_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02717_pat_hprc_r2_v1.0.1,61834019
-HG01071,1,s3://human-pangenomics/working/HPRC/HG01071/assemblies/release2/annotation/cat/HG01071_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01071_pat_hprc_r2_v1.0.1,63163680
-HG01346,1,s3://human-pangenomics/working/HPRC/HG01346/assemblies/release2/annotation/cat/HG01346_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01346_pat_hprc_r2_v1.0.1,63675339
-NA19087,2,s3://human-pangenomics/working/HPRC/NA19087/assemblies/release2/annotation/cat/NA19087_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA19087_hap2_hprc_r2_v1.0.1,62758358
-HG00658,2,s3://human-pangenomics/working/HPRC/HG00658/assemblies/release2/annotation/cat/HG00658_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00658_mat_hprc_r2_v1.0.1,63460783
-HG03704,2,s3://human-pangenomics/working/HPRC/HG03704/assemblies/release2/annotation/cat/HG03704_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03704_mat_hprc_r2_v1.0.1,63525667
-NA18906,2,s3://human-pangenomics/working/HPRC_PLUS/NA18906/assemblies/release2/annotation/cat/NA18906_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18906_mat_hprc_r2_v1.0.1,61718797
-NA20346,2,s3://human-pangenomics/working/HPRC/NA20346/assemblies/release2/annotation/cat/NA20346_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA20346_hap2_hprc_r2_v1.0.1,63434175
-NA18570,2,s3://human-pangenomics/working/HPRC/NA18570/assemblies/release2/annotation/cat/NA18570_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18570_hap2_hprc_r2_v1.0.1,63395747
-HG03225,1,s3://human-pangenomics/working/HPRC/HG03225/assemblies/release2/annotation/cat/HG03225_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03225_hap1_hprc_r2_v1.0.1,62141684
-HG02583,2,s3://human-pangenomics/working/HPRC/HG02583/assemblies/release2/annotation/cat/HG02583_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02583_hap2_hprc_r2_v1.0.1,63089653
-HG02165,1,s3://human-pangenomics/working/HPRC/HG02165/assemblies/release2/annotation/cat/HG02165_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02165_hap1_hprc_r2_v1.0.1,63387136
-HG01192,1,s3://human-pangenomics/working/HPRC/HG01192/assemblies/release2/annotation/cat/HG01192_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01192_pat_hprc_r2_v1.0.1,61788448
-NA21106,2,s3://human-pangenomics/working/HPRC/NA21106/assemblies/release2/annotation/cat/NA21106_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA21106_hap2_hprc_r2_v1.0.1,63801433
-HG01258,1,s3://human-pangenomics/working/HPRC/HG01258/assemblies/release2/annotation/cat/HG01258_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01258_pat_hprc_r2_v1.0.1,61485554
-HG03784,2,s3://human-pangenomics/working/HPRC/HG03784/assemblies/release2/annotation/cat/HG03784_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03784_hap2_hprc_r2_v1.0.1,63288036
-HG00738,2,s3://human-pangenomics/working/HPRC/HG00738/assemblies/release2/annotation/cat/HG00738_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00738_mat_hprc_r2_v1.0.1,63410724
-HG01175,2,s3://human-pangenomics/working/HPRC/HG01175/assemblies/release2/annotation/cat/HG01175_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01175_mat_hprc_r2_v1.0.1,63302509
-HG03195,1,s3://human-pangenomics/working/HPRC/HG03195/assemblies/release2/annotation/cat/HG03195_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03195_hap1_hprc_r2_v1.0.1,63542204
-HG02015,2,s3://human-pangenomics/working/HPRC/HG02015/assemblies/release2/annotation/cat/HG02015_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02015_mat_hprc_r2_v1.0.1,63517216
-HG03583,1,s3://human-pangenomics/working/HPRC/HG03583/assemblies/release2/annotation/cat/HG03583_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03583_hap1_hprc_r2_v1.0.1,63530076
-NA19338,2,s3://human-pangenomics/working/HPRC/NA19338/assemblies/release2/annotation/cat/NA19338_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA19338_hap2_hprc_r2_v1.0.1,62870895
-HG02135,2,s3://human-pangenomics/working/HPRC/HG02135/assemblies/release2/annotation/cat/HG02135_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02135_mat_hprc_r2_v1.0.1,63183119
-HG03471,2,s3://human-pangenomics/working/HPRC/HG03471/assemblies/release2/annotation/cat/HG03471_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03471_hap2_hprc_r2_v1.0.1,61782033
-HG03270,1,s3://human-pangenomics/working/HPRC/HG03270/assemblies/release2/annotation/cat/HG03270_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03270_hap1_hprc_r2_v1.0.1,63279670
-HG00133,1,s3://human-pangenomics/working/HPRC/HG00133/assemblies/release2/annotation/cat/HG00133_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00133_hap1_hprc_r2_v1.0.1,63216022
-HG03209,1,s3://human-pangenomics/working/HPRC/HG03209/assemblies/release2/annotation/cat/HG03209_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03209_hap1_hprc_r2_v1.0.1,61672754
-HG00706,1,s3://human-pangenomics/working/HPRC/HG00706/assemblies/release2/annotation/cat/HG00706_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00706_pat_hprc_r2_v1.0.1,61543171
-HG01786,2,s3://human-pangenomics/working/HPRC/HG01786/assemblies/release2/annotation/cat/HG01786_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01786_hap2_hprc_r2_v1.0.1,63425432
-HG00597,2,s3://human-pangenomics/working/HPRC/HG00597/assemblies/release2/annotation/cat/HG00597_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00597_mat_hprc_r2_v1.0.1,63755291
-NA18522,2,s3://human-pangenomics/working/HPRC/NA18522/assemblies/release2/annotation/cat/NA18522_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18522_hap2_hprc_r2_v1.0.1,63746643
-NA18960,1,s3://human-pangenomics/working/HPP/NA18960/assemblies/release2/annotation/cat/NA18960_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18960_hap1_hprc_r2_v1.0.1,60158802
-HG02559,1,s3://human-pangenomics/working/HPRC/HG02559/assemblies/release2/annotation/cat/HG02559_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02559_pat_hprc_r2_v1.0.1,61730295
-HG00350,1,s3://human-pangenomics/working/HPRC/HG00350/assemblies/release2/annotation/cat/HG00350_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00350_hap1_hprc_r2_v1.0.1,63122478
-NA21093,2,s3://human-pangenomics/working/HPRC/NA21093/assemblies/release2/annotation/cat/NA21093_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA21093_hap2_hprc_r2_v1.0.1,63454983
-HG01934,1,s3://human-pangenomics/working/HPRC/HG01934/assemblies/release2/annotation/cat/HG01934_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01934_pat_hprc_r2_v1.0.1,61540617
-HG00097,2,s3://human-pangenomics/working/HPRC/HG00097/assemblies/release2/annotation/cat/HG00097_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00097_hap2_hprc_r2_v1.0.1,63194321
-NA19909,2,s3://human-pangenomics/working/HPRC/NA19909/assemblies/release2/annotation/cat/NA19909_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA19909_hap2_hprc_r2_v1.0.1,63267088
-NA20827,2,s3://human-pangenomics/working/HPRC/NA20827/assemblies/release2/annotation/cat/NA20827_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA20827_hap2_hprc_r2_v1.0.1,62369841
-HG01109,2,s3://human-pangenomics/working/HPRC_PLUS/HG01109/assemblies/release2/annotation/cat/HG01109_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01109_mat_hprc_r2_v1.0.1,61759651
-HG00128,1,s3://human-pangenomics/working/HPRC/HG00128/assemblies/release2/annotation/cat/HG00128_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00128_hap1_hprc_r2_v1.0.1,63234923
-HG02074,1,s3://human-pangenomics/working/HPRC/HG02074/assemblies/release2/annotation/cat/HG02074_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02074_pat_hprc_r2_v1.0.1,61806970
-HG02027,1,s3://human-pangenomics/working/HPRC/HG02027/assemblies/release2/annotation/cat/HG02027_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02027_pat_hprc_r2_v1.0.1,61337892
-NA18970,2,s3://human-pangenomics/working/HPP/NA18970/assemblies/release2/annotation/cat/NA18970_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18970_hap2_hprc_r2_v1.0.1,63534793
-NA19043,2,s3://human-pangenomics/working/HPRC/NA19043/assemblies/release2/annotation/cat/NA19043_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA19043_hap2_hprc_r2_v1.0.1,63542093
-HG01358,1,s3://human-pangenomics/working/HPRC/HG01358/assemblies/release2/annotation/cat/HG01358_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01358_pat_hprc_r2_v1.0.1,61785574
-HG04187,1,s3://human-pangenomics/working/HPRC/HG04187/assemblies/release2/annotation/cat/HG04187_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG04187_pat_hprc_r2_v1.0.1,61572904
-HG02486,1,s3://human-pangenomics/working/HPRC/HG02486/assemblies/release2/annotation/cat/HG02486_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02486_pat_hprc_r2_v1.0.1,59941004
-HG01928,2,s3://human-pangenomics/working/HPRC/HG01928/assemblies/release2/annotation/cat/HG01928_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01928_mat_hprc_r2_v1.0.1,63193855
-HG02300,2,s3://human-pangenomics/working/HPRC/HG02300/assemblies/release2/annotation/cat/HG02300_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02300_mat_hprc_r2_v1.0.1,63326962
-NA19185,2,s3://human-pangenomics/working/HPRC/NA19185/assemblies/release2/annotation/cat/NA19185_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA19185_hap2_hprc_r2_v1.0.1,63397040
-HG00280,1,s3://human-pangenomics/working/HPRC/HG00280/assemblies/release2/annotation/cat/HG00280_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00280_hap1_hprc_r2_v1.0.1,61942403
-NA19909,1,s3://human-pangenomics/working/HPRC/NA19909/assemblies/release2/annotation/cat/NA19909_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA19909_hap1_hprc_r2_v1.0.1,63223026
-HG03041,1,s3://human-pangenomics/working/HPRC/HG03041/assemblies/release2/annotation/cat/HG03041_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03041_pat_hprc_r2_v1.0.1,63392646
-HG01074,2,s3://human-pangenomics/working/HPRC/HG01074/assemblies/release2/annotation/cat/HG01074_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01074_mat_hprc_r2_v1.0.1,63101756
-HG03139,2,s3://human-pangenomics/working/HPRC/HG03139/assemblies/release2/annotation/cat/HG03139_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03139_hap2_hprc_r2_v1.0.1,63636184
-HG01993,1,s3://human-pangenomics/working/HPRC/HG01993/assemblies/release2/annotation/cat/HG01993_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01993_pat_hprc_r2_v1.0.1,63356401
-NA19468,2,s3://human-pangenomics/working/HPRC/NA19468/assemblies/release2/annotation/cat/NA19468_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA19468_hap2_hprc_r2_v1.0.1,62624222
-HG02922,2,s3://human-pangenomics/working/HPRC/HG02922/assemblies/release2/annotation/cat/HG02922_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02922_hap2_hprc_r2_v1.0.1,63613912
-HG00280,2,s3://human-pangenomics/working/HPRC/HG00280/assemblies/release2/annotation/cat/HG00280_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00280_hap2_hprc_r2_v1.0.1,63562400
-HG00597,1,s3://human-pangenomics/working/HPRC/HG00597/assemblies/release2/annotation/cat/HG00597_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00597_pat_hprc_r2_v1.0.1,63559026
-NA21102,2,s3://human-pangenomics/working/HPRC/NA21102/assemblies/release2/annotation/cat/NA21102_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA21102_hap2_hprc_r2_v1.0.1,63219005
-NA21309,1,s3://human-pangenomics/working/HPRC_PLUS/NA21309/assemblies/release2/annotation/cat/NA21309_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA21309_pat_hprc_r2_v1.0.1,61809083
-HG03816,2,s3://human-pangenomics/working/HPRC/HG03816/assemblies/release2/annotation/cat/HG03816_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03816_mat_hprc_r2_v1.0.1,63345173
-NA20805,1,s3://human-pangenomics/working/HPRC/NA20805/assemblies/release2/annotation/cat/NA20805_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA20805_hap1_hprc_r2_v1.0.1,61386576
-HG03669,1,s3://human-pangenomics/working/HPRC/HG03669/assemblies/release2/annotation/cat/HG03669_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03669_pat_hprc_r2_v1.0.1,63360051
-HG02135,1,s3://human-pangenomics/working/HPRC/HG02135/assemblies/release2/annotation/cat/HG02135_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02135_pat_hprc_r2_v1.0.1,61575994
-HG02622,2,s3://human-pangenomics/working/HPRC/HG02622/assemblies/release2/annotation/cat/HG02622_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02622_mat_hprc_r2_v1.0.1,63652928
-HG03521,1,s3://human-pangenomics/working/HPRC/HG03521/assemblies/release2/annotation/cat/HG03521_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03521_hap1_hprc_r2_v1.0.1,61434143
-HG00621,2,s3://human-pangenomics/working/HPRC/HG00621/assemblies/release2/annotation/cat/HG00621_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00621_mat_hprc_r2_v1.0.1,63207146
-NA21144,2,s3://human-pangenomics/working/HPRC/NA21144/assemblies/release2/annotation/cat/NA21144_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA21144_hap2_hprc_r2_v1.0.1,63229738
-NA20129,1,s3://human-pangenomics/working/HPRC_PLUS/NA20129/assemblies/release2/annotation/cat/NA20129_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA20129_pat_hprc_r2_v1.0.1,61714152
-HG02572,1,s3://human-pangenomics/working/HPRC/HG02572/assemblies/release2/annotation/cat/HG02572_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02572_pat_hprc_r2_v1.0.1,61671329
-HG02056,1,s3://human-pangenomics/working/HPRC/HG02056/assemblies/release2/annotation/cat/HG02056_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02056_pat_hprc_r2_v1.0.1,61969889
-HG03130,1,s3://human-pangenomics/working/HPRC/HG03130/assemblies/release2/annotation/cat/HG03130_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03130_hap1_hprc_r2_v1.0.1,61989305
-HG00350,2,s3://human-pangenomics/working/HPRC/HG00350/assemblies/release2/annotation/cat/HG00350_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00350_hap2_hprc_r2_v1.0.1,63309610
-NA18608,2,s3://human-pangenomics/working/HPRC/NA18608/assemblies/release2/annotation/cat/NA18608_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18608_hap2_hprc_r2_v1.0.1,63436468
-NA21102,1,s3://human-pangenomics/working/HPRC/NA21102/assemblies/release2/annotation/cat/NA21102_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA21102_hap1_hprc_r2_v1.0.1,63171610
-HG02273,2,s3://human-pangenomics/working/HPRC/HG02273/assemblies/release2/annotation/cat/HG02273_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02273_hap2_hprc_r2_v1.0.1,63709205
-HG03017,2,s3://human-pangenomics/working/HPRC/HG03017/assemblies/release2/annotation/cat/HG03017_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03017_mat_hprc_r2_v1.0.1,63252719
-NA18879,2,s3://human-pangenomics/working/HPRC/NA18879/assemblies/release2/annotation/cat/NA18879_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18879_hap2_hprc_r2_v1.0.1,63342467
-HG00738,1,s3://human-pangenomics/working/HPRC/HG00738/assemblies/release2/annotation/cat/HG00738_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00738_pat_hprc_r2_v1.0.1,61491466
-HG02984,1,s3://human-pangenomics/working/HPRC/HG02984/assemblies/release2/annotation/cat/HG02984_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02984_pat_hprc_r2_v1.0.1,61614080
-NA19391,1,s3://human-pangenomics/working/HPRC/NA19391/assemblies/release2/annotation/cat/NA19391_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA19391_hap1_hprc_r2_v1.0.1,63650432
-HG02148,2,s3://human-pangenomics/working/HPRC/HG02148/assemblies/release2/annotation/cat/HG02148_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02148_mat_hprc_r2_v1.0.1,63203634
-HG02572,2,s3://human-pangenomics/working/HPRC/HG02572/assemblies/release2/annotation/cat/HG02572_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02572_mat_hprc_r2_v1.0.1,63468364
-HG02392,2,s3://human-pangenomics/working/HPRC/HG02392/assemblies/release2/annotation/cat/HG02392_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02392_hap2_hprc_r2_v1.0.1,63450581
-HG02056,2,s3://human-pangenomics/working/HPRC/HG02056/assemblies/release2/annotation/cat/HG02056_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02056_mat_hprc_r2_v1.0.1,63530526
-HG00558,1,s3://human-pangenomics/working/HPRC/HG00558/assemblies/release2/annotation/cat/HG00558_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00558_pat_hprc_r2_v1.0.1,63455908
-NA19159,1,s3://human-pangenomics/working/HPRC/NA19159/assemblies/release2/annotation/cat/NA19159_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA19159_hap1_hprc_r2_v1.0.1,61590507
-HG00146,1,s3://human-pangenomics/working/HPRC/HG00146/assemblies/release2/annotation/cat/HG00146_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00146_hap1_hprc_r2_v1.0.1,63473413
-HG04184,2,s3://human-pangenomics/working/HPRC/HG04184/assemblies/release2/annotation/cat/HG04184_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG04184_mat_hprc_r2_v1.0.1,61758906
-NA19391,2,s3://human-pangenomics/working/HPRC/NA19391/assemblies/release2/annotation/cat/NA19391_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA19391_hap2_hprc_r2_v1.0.1,63501169
-HG03942,2,s3://human-pangenomics/working/HPRC/HG03942/assemblies/release2/annotation/cat/HG03942_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03942_mat_hprc_r2_v1.0.1,63110764
-HG03369,2,s3://human-pangenomics/working/HPRC/HG03369/assemblies/release2/annotation/cat/HG03369_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03369_hap2_hprc_r2_v1.0.1,63217679
-HG03874,1,s3://human-pangenomics/working/HPRC/HG03874/assemblies/release2/annotation/cat/HG03874_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03874_hap1_hprc_r2_v1.0.1,63641220
-HG00423,2,s3://human-pangenomics/working/HPRC/HG00423/assemblies/release2/annotation/cat/HG00423_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00423_mat_hprc_r2_v1.0.1,62941730
-HG01192,2,s3://human-pangenomics/working/HPRC/HG01192/assemblies/release2/annotation/cat/HG01192_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01192_mat_hprc_r2_v1.0.1,63375125
-HG02615,1,s3://human-pangenomics/working/HPRC/HG02615/assemblies/release2/annotation/cat/HG02615_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02615_pat_hprc_r2_v1.0.1,63108984
-HG02647,2,s3://human-pangenomics/working/HPRC/HG02647/assemblies/release2/annotation/cat/HG02647_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02647_mat_hprc_r2_v1.0.1,63483677
-HG01496,1,s3://human-pangenomics/working/HPRC/HG01496/assemblies/release2/annotation/cat/HG01496_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01496_pat_hprc_r2_v1.0.1,63492360
-HG02630,2,s3://human-pangenomics/working/HPRC/HG02630/assemblies/release2/annotation/cat/HG02630_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02630_mat_hprc_r2_v1.0.1,63371207
-HG01530,2,s3://human-pangenomics/working/HPRC/HG01530/assemblies/release2/annotation/cat/HG01530_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01530_hap2_hprc_r2_v1.0.1,63231634
-HG01150,1,s3://human-pangenomics/working/HPRC/HG01150/assemblies/release2/annotation/cat/HG01150_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01150_pat_hprc_r2_v1.0.1,63486179
-NA18960,2,s3://human-pangenomics/working/HPP/NA18960/assemblies/release2/annotation/cat/NA18960_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18960_hap2_hprc_r2_v1.0.1,61744809
-HG00544,2,s3://human-pangenomics/working/HPRC/HG00544/assemblies/release2/annotation/cat/HG00544_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00544_mat_hprc_r2_v1.0.1,63086453
-HG02391,2,s3://human-pangenomics/working/HPRC/HG02391/assemblies/release2/annotation/cat/HG02391_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02391_hap2_hprc_r2_v1.0.1,63612702
-HG02145,1,s3://human-pangenomics/working/HPRC_PLUS/HG02145/assemblies/release2/annotation/cat/HG02145_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02145_pat_hprc_r2_v1.0.1,60054640
-NA18608,1,s3://human-pangenomics/working/HPRC/NA18608/assemblies/release2/annotation/cat/NA18608_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18608_hap1_hprc_r2_v1.0.1,62038129
-HG00126,2,s3://human-pangenomics/working/HPRC/HG00126/assemblies/release2/annotation/cat/HG00126_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00126_hap2_hprc_r2_v1.0.1,63362497
-HG03816,1,s3://human-pangenomics/working/HPRC/HG03816/assemblies/release2/annotation/cat/HG03816_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03816_pat_hprc_r2_v1.0.1,63409218
-NA18508,1,s3://human-pangenomics/working/HPRC/NA18508/assemblies/release2/annotation/cat/NA18508_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18508_hap1_hprc_r2_v1.0.1,63201026
-HG03742,2,s3://human-pangenomics/working/HPRC/HG03742/assemblies/release2/annotation/cat/HG03742_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03742_hap2_hprc_r2_v1.0.1,63431903
-NA19776,1,s3://human-pangenomics/working/HPRC/NA19776/assemblies/release2/annotation/cat/NA19776_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA19776_hap1_hprc_r2_v1.0.1,63211890
-HG00639,1,s3://human-pangenomics/working/HPRC/HG00639/assemblies/release2/annotation/cat/HG00639_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00639_pat_hprc_r2_v1.0.1,63259100
-NA20850,1,s3://human-pangenomics/working/HPRC/NA20850/assemblies/release2/annotation/cat/NA20850_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA20850_hap1_hprc_r2_v1.0.1,61477806
-HG03669,2,s3://human-pangenomics/working/HPRC/HG03669/assemblies/release2/annotation/cat/HG03669_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03669_mat_hprc_r2_v1.0.1,63099864
-NA19043,1,s3://human-pangenomics/working/HPRC/NA19043/assemblies/release2/annotation/cat/NA19043_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA19043_hap1_hprc_r2_v1.0.1,61768908
-HG03927,1,s3://human-pangenomics/working/HPRC/HG03927/assemblies/release2/annotation/cat/HG03927_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03927_pat_hprc_r2_v1.0.1,63435891
-HG02109,1,s3://human-pangenomics/working/HPRC_PLUS/HG02109/assemblies/release2/annotation/cat/HG02109_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02109_pat_hprc_r2_v1.0.1,61586163
-NA19835,2,s3://human-pangenomics/working/HPRC/NA19835/assemblies/release2/annotation/cat/NA19835_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA19835_hap2_hprc_r2_v1.0.1,63487478
-HG02392,1,s3://human-pangenomics/working/HPRC/HG02392/assemblies/release2/annotation/cat/HG02392_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02392_hap1_hprc_r2_v1.0.1,62142102
-HG03834,1,s3://human-pangenomics/working/HPRC/HG03834/assemblies/release2/annotation/cat/HG03834_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03834_pat_hprc_r2_v1.0.1,63422562
-HG00099,2,s3://human-pangenomics/working/HPRC/HG00099/assemblies/release2/annotation/cat/HG00099_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00099_hap2_hprc_r2_v1.0.1,63678632
-NA18943,1,s3://human-pangenomics/working/HPP/NA18943/assemblies/release2/annotation/cat/NA18943_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18943_hap1_hprc_r2_v1.0.1,60196480
-NA19835,1,s3://human-pangenomics/working/HPRC/NA19835/assemblies/release2/annotation/cat/NA19835_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA19835_hap1_hprc_r2_v1.0.1,63278054
-HG04160,2,s3://human-pangenomics/working/HPRC/HG04160/assemblies/release2/annotation/cat/HG04160_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG04160_mat_hprc_r2_v1.0.1,63591579
-HG02129,1,s3://human-pangenomics/working/HPRC/HG02129/assemblies/release2/annotation/cat/HG02129_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02129_pat_hprc_r2_v1.0.1,62010384
-HG04160,1,s3://human-pangenomics/working/HPRC/HG04160/assemblies/release2/annotation/cat/HG04160_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG04160_pat_hprc_r2_v1.0.1,61706205
-HG00099,1,s3://human-pangenomics/working/HPRC/HG00099/assemblies/release2/annotation/cat/HG00099_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00099_hap1_hprc_r2_v1.0.1,63503727
-HG03130,2,s3://human-pangenomics/working/HPRC/HG03130/assemblies/release2/annotation/cat/HG03130_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03130_hap2_hprc_r2_v1.0.1,63547850
-HG02922,1,s3://human-pangenomics/working/HPRC/HG02922/assemblies/release2/annotation/cat/HG02922_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02922_hap1_hprc_r2_v1.0.1,63723527
-HG02514,1,s3://human-pangenomics/working/HPRC/HG02514/assemblies/release2/annotation/cat/HG02514_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02514_pat_hprc_r2_v1.0.1,61812039
-HG01993,2,s3://human-pangenomics/working/HPRC/HG01993/assemblies/release2/annotation/cat/HG01993_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01993_mat_hprc_r2_v1.0.1,63432937
-HG02976,1,s3://human-pangenomics/working/HPRC/HG02976/assemblies/release2/annotation/cat/HG02976_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02976_hap1_hprc_r2_v1.0.1,64292824
-HG01243,2,s3://human-pangenomics/working/HPRC_PLUS/HG01243/assemblies/release2/annotation/cat/HG01243_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01243_mat_hprc_r2_v1.0.1,61689853
-HG03540,2,s3://human-pangenomics/working/HPRC/HG03540/assemblies/release2/annotation/cat/HG03540_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03540_mat_hprc_r2_v1.0.1,63584852
-HG01071,2,s3://human-pangenomics/working/HPRC/HG01071/assemblies/release2/annotation/cat/HG01071_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01071_mat_hprc_r2_v1.0.1,63236298
-HG03516,2,s3://human-pangenomics/working/HPRC/HG03516/assemblies/release2/annotation/cat/HG03516_mat_hprc_r2_v1.1.0_cat_v1.1.gff3.gz,CAT Genes,2,HG03516_mat_hprc_r2_v1.1.0,63664802
-HG02027,2,s3://human-pangenomics/working/HPRC/HG02027/assemblies/release2/annotation/cat/HG02027_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02027_mat_hprc_r2_v1.0.1,63183397
-HG03784,1,s3://human-pangenomics/working/HPRC/HG03784/assemblies/release2/annotation/cat/HG03784_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03784_hap1_hprc_r2_v1.0.1,63290435
-HG00733,1,s3://human-pangenomics/working/HPRC_PLUS/HG00733/assemblies/release2/annotation/cat/HG00733_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00733_pat_hprc_r2_v1.0.1,61789692
-HG02602,2,s3://human-pangenomics/working/HPRC/HG02602/assemblies/release2/annotation/cat/HG02602_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02602_mat_hprc_r2_v1.0.1,63515629
-NA19240,2,s3://human-pangenomics/working/HPRC_PLUS/NA19240/assemblies/release2/annotation/cat/NA19240_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA19240_mat_hprc_r2_v1.0.1,61632708
-HG03209,2,s3://human-pangenomics/working/HPRC/HG03209/assemblies/release2/annotation/cat/HG03209_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03209_hap2_hprc_r2_v1.0.1,63425815
-HG01433,1,s3://human-pangenomics/working/HPRC/HG01433/assemblies/release2/annotation/cat/HG01433_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01433_pat_hprc_r2_v1.0.1,61800394
-HG00733,2,s3://human-pangenomics/working/HPRC_PLUS/HG00733/assemblies/release2/annotation/cat/HG00733_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00733_mat_hprc_r2_v1.0.1,61885565
-HG03470,2,s3://human-pangenomics/working/HPRC/HG03470/assemblies/release2/annotation/cat/HG03470_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03470_hap2_hprc_r2_v1.0.1,63475884
-HG00140,2,s3://human-pangenomics/working/HPRC/HG00140/assemblies/release2/annotation/cat/HG00140_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00140_hap2_hprc_r2_v1.0.1,63802665
-NA20806,1,s3://human-pangenomics/working/HPRC/NA20806/assemblies/release2/annotation/cat/NA20806_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA20806_hap1_hprc_r2_v1.0.1,61494055
-NA18522,1,s3://human-pangenomics/working/HPRC/NA18522/assemblies/release2/annotation/cat/NA18522_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18522_hap1_hprc_r2_v1.0.1,62126694
-HG03831,2,s3://human-pangenomics/working/HPRC/HG03831/assemblies/release2/annotation/cat/HG03831_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03831_mat_hprc_r2_v1.0.1,63486578
-HG00609,1,s3://human-pangenomics/working/HPRC/HG00609/assemblies/release2/annotation/cat/HG00609_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00609_pat_hprc_r2_v1.0.1,61783498
-HG01099,1,s3://human-pangenomics/working/HPRC/HG01099/assemblies/release2/annotation/cat/HG01099_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01099_pat_hprc_r2_v1.0.1,61540379
-HG02965,2,s3://human-pangenomics/working/HPRC/HG02965/assemblies/release2/annotation/cat/HG02965_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02965_hap2_hprc_r2_v1.0.1,63511173
-HG03239,1,s3://human-pangenomics/working/HPRC/HG03239/assemblies/release2/annotation/cat/HG03239_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03239_pat_hprc_r2_v1.0.1,63327467
-NA18974,2,s3://human-pangenomics/working/HPRC/NA18974/assemblies/release2/annotation/cat/NA18974_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18974_hap2_hprc_r2_v1.0.1,63593638
-HG03583,2,s3://human-pangenomics/working/HPRC/HG03583/assemblies/release2/annotation/cat/HG03583_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03583_hap2_hprc_r2_v1.0.1,63203062
-HG00735,2,s3://human-pangenomics/working/HPRC/HG00735/assemblies/release2/annotation/cat/HG00735_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00735_mat_hprc_r2_v1.0.1,63214109
-HG02559,2,s3://human-pangenomics/working/HPRC/HG02559/assemblies/release2/annotation/cat/HG02559_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02559_mat_hprc_r2_v1.0.1,61800518
-HG03874,2,s3://human-pangenomics/working/HPRC/HG03874/assemblies/release2/annotation/cat/HG03874_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03874_hap2_hprc_r2_v1.0.1,63487506
-HG06807,2,s3://human-pangenomics/working/HPRC/HG06807/assemblies/release2/annotation/cat/HG06807_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG06807_mat_v1,61070159
-HG03098,1,s3://human-pangenomics/working/HPRC_PLUS/HG03098/assemblies/release2/annotation/cat/HG03098_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03098_pat_hprc_r2_v1.0.1,59877579
-NA20799,2,s3://human-pangenomics/working/HPRC/NA20799/assemblies/release2/annotation/cat/NA20799_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA20799_hap2_hprc_r2_v1.0.1,63351230
-HG03579,1,s3://human-pangenomics/working/HPRC/HG03579/assemblies/release2/annotation/cat/HG03579_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03579_pat_hprc_r2_v1.0.1,61386600
-NA18620,2,s3://human-pangenomics/working/HPRC/NA18620/assemblies/release2/annotation/cat/NA18620_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18620_hap2_hprc_r2_v1.0.1,63730026
-NA18948,1,s3://human-pangenomics/working/HPP/NA18948/assemblies/release2/annotation/cat/NA18948_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18948_hap1_hprc_r2_v1.0.1,60093160
-NA20752,2,s3://human-pangenomics/working/HPRC/NA20752/assemblies/release2/annotation/cat/NA20752_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA20752_hap2_hprc_r2_v1.0.1,63570013
-HG04184,1,s3://human-pangenomics/working/HPRC/HG04184/assemblies/release2/annotation/cat/HG04184_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG04184_pat_hprc_r2_v1.0.1,61779075
-NA18945,1,s3://human-pangenomics/working/HPP/NA18945/assemblies/release2/annotation/cat/NA18945_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18945_hap1_hprc_r2_v1.0.1,59969198
-HG03704,1,s3://human-pangenomics/working/HPRC/HG03704/assemblies/release2/annotation/cat/HG03704_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03704_pat_hprc_r2_v1.0.1,63414042
-HG02451,2,s3://human-pangenomics/working/HPRC/HG02451/assemblies/release2/annotation/cat/HG02451_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02451_mat_hprc_r2_v1.0.1,63033218
-HG02886,1,s3://human-pangenomics/working/HPRC/HG02886/assemblies/release2/annotation/cat/HG02886_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02886_pat_hprc_r2_v1.0.1,63590169
-HG00290,2,s3://human-pangenomics/working/HPRC/HG00290/assemblies/release2/annotation/cat/HG00290_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00290_hap2_hprc_r2_v1.0.1,63487259
-NA18982,2,s3://human-pangenomics/working/HPP/NA18982/assemblies/release2/annotation/cat/NA18982_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18982_hap2_hprc_r2_v1.0.1,60855520
-HG02738,2,s3://human-pangenomics/working/HPRC/HG02738/assemblies/release2/annotation/cat/HG02738_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02738_mat_hprc_r2_v1.0.1,63471555
-HG02083,2,s3://human-pangenomics/working/HPRC/HG02083/assemblies/release2/annotation/cat/HG02083_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02083_mat_hprc_r2_v1.0.1,63287980
-HG00408,1,s3://human-pangenomics/working/HPRC/HG00408/assemblies/release2/annotation/cat/HG00408_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00408_pat_hprc_r2_v1.0.1,63531417
-HG03927,2,s3://human-pangenomics/working/HPRC/HG03927/assemblies/release2/annotation/cat/HG03927_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03927_mat_hprc_r2_v1.0.1,63532482
-HG01960,1,s3://human-pangenomics/working/HPRC/HG01960/assemblies/release2/annotation/cat/HG01960_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01960_pat_hprc_r2_v1.0.1,63491289
-HG00344,2,s3://human-pangenomics/working/HPRC/HG00344/assemblies/release2/annotation/cat/HG00344_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00344_hap2_hprc_r2_v1.0.1,63214204
-HG02818,1,s3://human-pangenomics/working/HPRC_PLUS/HG02818/assemblies/release2/annotation/cat/HG02818_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02818_pat_hprc_r2_v1.0.1,61663688
-HG02698,1,s3://human-pangenomics/working/HPRC/HG02698/assemblies/release2/annotation/cat/HG02698_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02698_pat_hprc_r2_v1.0.1,61567246
-HG02015,1,s3://human-pangenomics/working/HPRC/HG02015/assemblies/release2/annotation/cat/HG02015_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02015_pat_hprc_r2_v1.0.1,61721144
-HG03041,2,s3://human-pangenomics/working/HPRC/HG03041/assemblies/release2/annotation/cat/HG03041_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03041_mat_hprc_r2_v1.0.1,63345117
-HG04199,1,s3://human-pangenomics/working/HPRC/HG04199/assemblies/release2/annotation/cat/HG04199_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG04199_pat_hprc_r2_v1.0.1,61672428
-HG01167,2,s3://human-pangenomics/working/HPRC/HG01167/assemblies/release2/annotation/cat/HG01167_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01167_hap2_hprc_r2_v1.0.1,63229432
-HG03804,1,s3://human-pangenomics/working/HPRC/HG03804/assemblies/release2/annotation/cat/HG03804_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03804_pat_hprc_r2_v1.0.1,63505892
-HG01123,1,s3://human-pangenomics/working/HPRC/HG01123/assemblies/release2/annotation/cat/HG01123_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01123_pat_hprc_r2_v1.0.1,61771763
-NA20905,1,s3://human-pangenomics/working/HPRC/NA20905/assemblies/release2/annotation/cat/NA20905_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA20905_hap1_hprc_r2_v1.0.1,61802599
-HG03831,1,s3://human-pangenomics/working/HPRC/HG03831/assemblies/release2/annotation/cat/HG03831_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03831_pat_hprc_r2_v1.0.1,63578151
-HG01433,2,s3://human-pangenomics/working/HPRC/HG01433/assemblies/release2/annotation/cat/HG01433_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01433_mat_hprc_r2_v1.0.1,63350553
-NA18944,1,s3://human-pangenomics/working/HPP/NA18944/assemblies/release2/annotation/cat/NA18944_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18944_hap1_hprc_r2_v1.0.1,60122199
-NA19682,2,s3://human-pangenomics/working/HPRC/NA19682/assemblies/release2/annotation/cat/NA19682_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA19682_hap2_hprc_r2_v1.0.1,63484142
-HG03486,2,s3://human-pangenomics/working/HPRC_PLUS/HG03486/assemblies/release2/annotation/cat/HG03486_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03486_mat_hprc_r2_v1.0.1,61814609
-HG02257,1,s3://human-pangenomics/working/HPRC/HG02257/assemblies/release2/annotation/cat/HG02257_pat_hprc_r2_v1.1.0_cat_v1.1.gff3.gz,CAT Genes,2,HG02257_pat_hprc_r2_v1.1.0,63550666
-HG02280,2,s3://human-pangenomics/working/HPRC/HG02280/assemblies/release2/annotation/cat/HG02280_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02280_mat_hprc_r2_v1.0.1,63673333
-NA18505,2,s3://human-pangenomics/working/HPRC/NA18505/assemblies/release2/annotation/cat/NA18505_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18505_hap2_hprc_r2_v1.0.1,64021324
-NA19468,1,s3://human-pangenomics/working/HPRC/NA19468/assemblies/release2/annotation/cat/NA19468_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA19468_hap1_hprc_r2_v1.0.1,63267384
-HG02668,2,s3://human-pangenomics/working/HPRC/HG02668/assemblies/release2/annotation/cat/HG02668_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02668_mat_hprc_r2_v1.0.1,63258706
-HG02280,1,s3://human-pangenomics/working/HPRC/HG02280/assemblies/release2/annotation/cat/HG02280_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02280_pat_hprc_r2_v1.0.1,63671152
-HG02809,2,s3://human-pangenomics/working/HPRC/HG02809/assemblies/release2/annotation/cat/HG02809_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02809_mat_hprc_r2_v1.0.1,63517842
-HG01252,2,s3://human-pangenomics/working/HPRC/HG01252/assemblies/release2/annotation/cat/HG01252_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01252_mat_hprc_r2_v1.0.1,63335642
-NA20752,1,s3://human-pangenomics/working/HPRC/NA20752/assemblies/release2/annotation/cat/NA20752_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA20752_hap1_hprc_r2_v1.0.1,61832191
-HG01952,1,s3://human-pangenomics/working/HPRC/HG01952/assemblies/release2/annotation/cat/HG01952_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01952_pat_hprc_r2_v1.0.1,61504419
-HG02668,1,s3://human-pangenomics/working/HPRC/HG02668/assemblies/release2/annotation/cat/HG02668_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02668_pat_hprc_r2_v1.0.1,61734771
-HG02148,1,s3://human-pangenomics/working/HPRC/HG02148/assemblies/release2/annotation/cat/HG02148_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02148_pat_hprc_r2_v1.0.1,63324846
-HG01361,1,s3://human-pangenomics/working/HPRC/HG01361/assemblies/release2/annotation/cat/HG01361_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01361_pat_hprc_r2_v1.0.1,63383867
-HG02984,2,s3://human-pangenomics/working/HPRC/HG02984/assemblies/release2/annotation/cat/HG02984_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02984_mat_hprc_r2_v1.0.1,63176522
-NA18508,2,s3://human-pangenomics/working/HPRC/NA18508/assemblies/release2/annotation/cat/NA18508_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18508_hap2_hprc_r2_v1.0.1,63595303
-NA18944,2,s3://human-pangenomics/working/HPP/NA18944/assemblies/release2/annotation/cat/NA18944_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18944_hap2_hprc_r2_v1.0.1,61644253
-HG01106,1,s3://human-pangenomics/working/HPRC/HG01106/assemblies/release2/annotation/cat/HG01106_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01106_pat_hprc_r2_v1.0.1,61635483
-HG04228,2,s3://human-pangenomics/working/HPRC/HG04228/assemblies/release2/annotation/cat/HG04228_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG04228_mat_hprc_r2_v1.0.1,63144800
-HG03942,1,s3://human-pangenomics/working/HPRC/HG03942/assemblies/release2/annotation/cat/HG03942_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03942_pat_hprc_r2_v1.0.1,61373692
-HG04204,2,s3://human-pangenomics/working/HPRC/HG04204/assemblies/release2/annotation/cat/HG04204_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG04204_mat_hprc_r2_v1.0.1,63452438
-HG04228,1,s3://human-pangenomics/working/HPRC/HG04228/assemblies/release2/annotation/cat/HG04228_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG04228_pat_hprc_r2_v1.0.1,61631928
-HG02615,2,s3://human-pangenomics/working/HPRC/HG02615/assemblies/release2/annotation/cat/HG02615_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02615_mat_hprc_r2_v1.0.1,63140179
-HG00253,2,s3://human-pangenomics/working/HPRC/HG00253/assemblies/release2/annotation/cat/HG00253_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00253_hap2_hprc_r2_v1.0.1,63452615
-NA18505,1,s3://human-pangenomics/working/HPRC/NA18505/assemblies/release2/annotation/cat/NA18505_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18505_hap1_hprc_r2_v1.0.1,63932005
-HG03804,2,s3://human-pangenomics/working/HPRC/HG03804/assemblies/release2/annotation/cat/HG03804_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03804_mat_hprc_r2_v1.0.1,63489207
-HG01975,2,s3://human-pangenomics/working/HPRC/HG01975/assemblies/release2/annotation/cat/HG01975_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01975_mat_hprc_r2_v1.0.1,63499823
-HG03710,1,s3://human-pangenomics/working/HPRC/HG03710/assemblies/release2/annotation/cat/HG03710_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03710_pat_hprc_r2_v1.0.1,61805207
-HG00235,2,s3://human-pangenomics/working/HPRC/HG00235/assemblies/release2/annotation/cat/HG00235_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00235_hap2_hprc_r2_v1.0.1,63459446
-HG02258,2,s3://human-pangenomics/working/HPRC/HG02258/assemblies/release2/annotation/cat/HG02258_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02258_mat_hprc_r2_v1.0.1,63495257
-HG02583,1,s3://human-pangenomics/working/HPRC/HG02583/assemblies/release2/annotation/cat/HG02583_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02583_hap1_hprc_r2_v1.0.1,63196877
-HG01940,2,s3://human-pangenomics/working/HPRC/HG01940/assemblies/release2/annotation/cat/HG01940_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01940_mat_hprc_r2_v1.0.1,63406720
-HG00128,2,s3://human-pangenomics/working/HPRC/HG00128/assemblies/release2/annotation/cat/HG00128_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00128_hap2_hprc_r2_v1.0.1,63216826
-NA18971,1,s3://human-pangenomics/working/HPRC/NA18971/assemblies/release2/annotation/cat/NA18971_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18971_hap1_hprc_r2_v1.0.1,61564122
-HG01969,1,s3://human-pangenomics/working/HPRC/HG01969/assemblies/release2/annotation/cat/HG01969_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01969_pat_hprc_r2_v1.0.1,63295274
-NA19443,2,s3://human-pangenomics/working/HPRC/NA19443/assemblies/release2/annotation/cat/NA19443_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA19443_hap2_hprc_r2_v1.0.1,63303186
-HG01943,2,s3://human-pangenomics/working/HPRC/HG01943/assemblies/release2/annotation/cat/HG01943_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01943_mat_hprc_r2_v1.0.1,63385845
-NA18747,1,s3://human-pangenomics/working/HPRC/NA18747/assemblies/release2/annotation/cat/NA18747_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18747_hap1_hprc_r2_v1.0.1,61202974
-NA21309,2,s3://human-pangenomics/working/HPRC_PLUS/NA21309/assemblies/release2/annotation/cat/NA21309_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA21309_mat_hprc_r2_v1.0.1,61762037
-NA21106,1,s3://human-pangenomics/working/HPRC/NA21106/assemblies/release2/annotation/cat/NA21106_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA21106_hap1_hprc_r2_v1.0.1,63689514
-NA18952,2,s3://human-pangenomics/working/HPRC/NA18952/assemblies/release2/annotation/cat/NA18952_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18952_hap2_hprc_r2_v1.0.1,63451854
-HG03654,2,s3://human-pangenomics/working/HPRC/HG03654/assemblies/release2/annotation/cat/HG03654_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG03654_mat_hprc_r2_v1.0.1,63706351
-NA18967,1,s3://human-pangenomics/working/HPP/NA18967/assemblies/release2/annotation/cat/NA18967_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18967_hap1_hprc_r2_v1.0.1,61903743
-HG00235,1,s3://human-pangenomics/working/HPRC/HG00235/assemblies/release2/annotation/cat/HG00235_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00235_hap1_hprc_r2_v1.0.1,63429083
-HG01358,2,s3://human-pangenomics/working/HPRC/HG01358/assemblies/release2/annotation/cat/HG01358_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01358_mat_hprc_r2_v1.0.1,63052976
-NA20905,2,s3://human-pangenomics/working/HPRC/NA20905/assemblies/release2/annotation/cat/NA20905_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA20905_hap2_hprc_r2_v1.0.1,63561731
-HG02451,1,s3://human-pangenomics/working/HPRC/HG02451/assemblies/release2/annotation/cat/HG02451_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02451_pat_hprc_r2_v1.0.1,63196185
-NA18983,1,s3://human-pangenomics/working/HPRC/NA18983/assemblies/release2/annotation/cat/NA18983_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18983_hap1_hprc_r2_v1.0.1,61547271
-HG01099,2,s3://human-pangenomics/working/HPRC/HG01099/assemblies/release2/annotation/cat/HG01099_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01099_mat_hprc_r2_v1.0.1,63141209
-HG01934,2,s3://human-pangenomics/working/HPRC/HG01934/assemblies/release2/annotation/cat/HG01934_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01934_mat_hprc_r2_v1.0.1,63408359
-NA19159,2,s3://human-pangenomics/working/HPRC/NA19159/assemblies/release2/annotation/cat/NA19159_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA19159_hap2_hprc_r2_v1.0.1,63299656
-HG00097,1,s3://human-pangenomics/working/HPRC/HG00097/assemblies/release2/annotation/cat/HG00097_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00097_hap1_hprc_r2_v1.0.1,63338462
-HG005,1,s3://human-pangenomics/working/HPRC_PLUS/HG005/assemblies/release2/annotation/cat/HG005_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG005_pat_hprc_r2_v1.0.1,59813888
-NA20805,2,s3://human-pangenomics/working/HPRC/NA20805/assemblies/release2/annotation/cat/NA20805_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA20805_hap2_hprc_r2_v1.0.1,63501629
-HG02818,2,s3://human-pangenomics/working/HPRC_PLUS/HG02818/assemblies/release2/annotation/cat/HG02818_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02818_mat_hprc_r2_v1.0.1,61629933
-HG00741,1,s3://human-pangenomics/working/HPRC/HG00741/assemblies/release2/annotation/cat/HG00741_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00741_pat_hprc_r2_v1.0.1,62988836
-HG02965,1,s3://human-pangenomics/working/HPRC/HG02965/assemblies/release2/annotation/cat/HG02965_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02965_hap1_hprc_r2_v1.0.1,61676457
-HG02273,1,s3://human-pangenomics/working/HPRC/HG02273/assemblies/release2/annotation/cat/HG02273_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02273_hap1_hprc_r2_v1.0.1,64027538
-HG02132,2,s3://human-pangenomics/working/HPRC/HG02132/assemblies/release2/annotation/cat/HG02132_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02132_mat_hprc_r2_v1.0.1,63097558
-HG01786,1,s3://human-pangenomics/working/HPRC/HG01786/assemblies/release2/annotation/cat/HG01786_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG01786_hap1_hprc_r2_v1.0.1,63380413
-HG02602,1,s3://human-pangenomics/working/HPRC/HG02602/assemblies/release2/annotation/cat/HG02602_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG02602_pat_hprc_r2_v1.0.1,61852327
-HG00146,2,s3://human-pangenomics/working/HPRC/HG00146/assemblies/release2/annotation/cat/HG00146_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,HG00146_hap2_hprc_r2_v1.0.1,63881048
-NA18570,1,s3://human-pangenomics/working/HPRC/NA18570/assemblies/release2/annotation/cat/NA18570_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz,CAT Genes,2,NA18570_hap1_hprc_r2_v1.0.1,63456011
+HG01081,1,s3://human-pangenomics/working/HPRC/HG01081/assemblies/release2/annotation/cat/HG01081_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01081_pat_hprc_r2_v1.0.1,111192883
+HG02647,1,s3://human-pangenomics/working/HPRC/HG02647/assemblies/release2/annotation/cat/HG02647_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02647_pat_hprc_r2_v1.0.1,109340026
+HG02622,1,s3://human-pangenomics/working/HPRC/HG02622/assemblies/release2/annotation/cat/HG02622_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02622_pat_hprc_r2_v1.0.1,112583808
+HG01361,2,s3://human-pangenomics/working/HPRC/HG01361/assemblies/release2/annotation/cat/HG01361_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01361_mat_hprc_r2_v1.0.1,112257333
+HG00735,1,s3://human-pangenomics/working/HPRC/HG00735/assemblies/release2/annotation/cat/HG00735_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00735_pat_hprc_r2_v1.0.1,110566837
+HG00321,2,s3://human-pangenomics/working/HPRC/HG00321/assemblies/release2/annotation/cat/HG00321_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00321_hap2_hprc_r2_v1.0.1,104003218
+HG03139,1,s3://human-pangenomics/working/HPRC/HG03139/assemblies/release2/annotation/cat/HG03139_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03139_hap1_hprc_r2_v1.0.1,109934983
+NA20346,1,s3://human-pangenomics/working/HPRC/NA20346/assemblies/release2/annotation/cat/NA20346_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA20346_hap1_hprc_r2_v1.0.1,108155123
+HG01960,2,s3://human-pangenomics/working/HPRC/HG01960/assemblies/release2/annotation/cat/HG01960_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01960_mat_hprc_r2_v1.0.1,111372393
+HG03453,2,s3://human-pangenomics/working/HPRC/HG03453/assemblies/release2/annotation/cat/HG03453_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03453_mat_hprc_r2_v1.0.1,113171858
+HG02165,2,s3://human-pangenomics/working/HPRC/HG02165/assemblies/release2/annotation/cat/HG02165_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02165_hap2_hprc_r2_v1.0.1,110454119
+HG02738,1,s3://human-pangenomics/working/HPRC/HG02738/assemblies/release2/annotation/cat/HG02738_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02738_pat_hprc_r2_v1.0.1,108384376
+HG02055,2,s3://human-pangenomics/working/HPRC_PLUS/HG02055/assemblies/release2/annotation/cat/HG02055_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02055_mat_hprc_r2_v1.0.1,104020785
+HG01261,2,s3://human-pangenomics/working/HPRC/HG01261/assemblies/release2/annotation/cat/HG01261_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01261_mat_hprc_r2_v1.0.1,110949327
+HG03742,1,s3://human-pangenomics/working/HPRC/HG03742/assemblies/release2/annotation/cat/HG03742_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03742_hap1_hprc_r2_v1.0.1,108758419
+NA19700,2,s3://human-pangenomics/working/HPRC/NA19700/assemblies/release2/annotation/cat/NA19700_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA19700_hap2_hprc_r2_v1.0.1,111990037
+NA18976,2,s3://human-pangenomics/working/HPRC/NA18976/assemblies/release2/annotation/cat/NA18976_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18976_hap2_hprc_r2_v1.0.1,110833061
+HG01981,2,s3://human-pangenomics/working/HPRC/HG01981/assemblies/release2/annotation/cat/HG01981_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01981_mat_hprc_r2_v1.0.1,111942318
+NA18967,2,s3://human-pangenomics/working/HPP/NA18967/assemblies/release2/annotation/cat/NA18967_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18967_hap2_hprc_r2_v1.0.1,110431369
+NA19036,1,s3://human-pangenomics/working/HPRC/NA19036/assemblies/release2/annotation/cat/NA19036_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA19036_hap1_hprc_r2_v1.0.1,111278794
+HG00329,1,s3://human-pangenomics/working/HPRC/HG00329/assemblies/release2/annotation/cat/HG00329_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00329_hap1_hprc_r2_v1.0.1,107532335
+NA18565,2,s3://human-pangenomics/working/HPRC/NA18565/assemblies/release2/annotation/cat/NA18565_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18565_hap2_hprc_r2_v1.0.1,110738448
+NA20503,1,s3://human-pangenomics/working/HPRC/NA20503/assemblies/release2/annotation/cat/NA20503_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA20503_hap1_hprc_r2_v1.0.1,110311174
+HG005,2,s3://human-pangenomics/working/HPRC_PLUS/HG005/assemblies/release2/annotation/cat/HG005_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG005_mat_hprc_r2_v1.0.1,103691109
+HG02055,1,s3://human-pangenomics/working/HPRC_PLUS/HG02055/assemblies/release2/annotation/cat/HG02055_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02055_pat_hprc_r2_v1.0.1,101279937
+HG02293,1,s3://human-pangenomics/working/HPRC/HG02293/assemblies/release2/annotation/cat/HG02293_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02293_pat_hprc_r2_v1.0.1,111417163
+NA18565,1,s3://human-pangenomics/working/HPRC/NA18565/assemblies/release2/annotation/cat/NA18565_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18565_hap1_hprc_r2_v1.0.1,110568730
+HG03654,1,s3://human-pangenomics/working/HPRC/HG03654/assemblies/release2/annotation/cat/HG03654_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03654_pat_hprc_r2_v1.0.1,109314013
+HG03516,1,s3://human-pangenomics/working/HPRC/HG03516/assemblies/release2/annotation/cat/HG03516_pat_hprc_r2_v1.1.0_cat_v1.3.gff3.gz,CAT Genes,2,HG03516_pat_hprc_r2_v1.1.0,112932271
+HG00609,2,s3://human-pangenomics/working/HPRC/HG00609/assemblies/release2/annotation/cat/HG00609_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00609_mat_hprc_r2_v1.0.1,111715476
+HG02080,2,s3://human-pangenomics/working/HPRC_PLUS/HG02080/assemblies/release2/annotation/cat/HG02080_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02080_mat_hprc_r2_v1.0.1,104027519
+HG00558,2,s3://human-pangenomics/working/HPRC/HG00558/assemblies/release2/annotation/cat/HG00558_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00558_mat_hprc_r2_v1.0.1,110849321
+HG02841,2,s3://human-pangenomics/working/HPRC/HG02841/assemblies/release2/annotation/cat/HG02841_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02841_mat_hprc_r2_v1.0.1,111499869
+HG02523,2,s3://human-pangenomics/working/HPRC/HG02523/assemblies/release2/annotation/cat/HG02523_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02523_mat_hprc_r2_v1.0.1,110216121
+HG00658,1,s3://human-pangenomics/working/HPRC/HG00658/assemblies/release2/annotation/cat/HG00658_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00658_pat_hprc_r2_v1.0.1,108523212
+HG02040,2,s3://human-pangenomics/working/HPRC/HG02040/assemblies/release2/annotation/cat/HG02040_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02040_hap2_hprc_r2_v1.0.1,112700100
+HG02004,1,s3://human-pangenomics/working/HPRC/HG02004/assemblies/release2/annotation/cat/HG02004_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02004_pat_hprc_r2_v1.0.1,111168176
+HG01243,1,s3://human-pangenomics/working/HPRC_PLUS/HG01243/assemblies/release2/annotation/cat/HG01243_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01243_pat_hprc_r2_v1.0.1,101026086
+NA20870,2,s3://human-pangenomics/working/HPRC/NA20870/assemblies/release2/annotation/cat/NA20870_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA20870_hap2_hprc_r2_v1.0.1,112134182
+HG01943,1,s3://human-pangenomics/working/HPRC/HG01943/assemblies/release2/annotation/cat/HG01943_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01943_pat_hprc_r2_v1.0.1,108969405
+HG03453,1,s3://human-pangenomics/working/HPRC/HG03453/assemblies/release2/annotation/cat/HG03453_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03453_pat_hprc_r2_v1.0.1,113402893
+HG03050,1,s3://human-pangenomics/working/HPRC/HG03050/assemblies/release2/annotation/cat/HG03050_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03050_pat_hprc_r2_v1.0.1,110454199
+HG02071,1,s3://human-pangenomics/working/HPRC/HG02071/assemblies/release2/annotation/cat/HG02071_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02071_pat_hprc_r2_v1.0.1,108286328
+HG00140,1,s3://human-pangenomics/working/HPRC/HG00140/assemblies/release2/annotation/cat/HG00140_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00140_hap1_hprc_r2_v1.0.1,108510327
+HG01784,2,s3://human-pangenomics/working/HPRC/HG01784/assemblies/release2/annotation/cat/HG01784_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01784_hap2_hprc_r2_v1.0.1,112095052
+HG04157,2,s3://human-pangenomics/working/HPRC/HG04157/assemblies/release2/annotation/cat/HG04157_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG04157_mat_hprc_r2_v1.0.1,112052843
+HG03540,1,s3://human-pangenomics/working/HPRC/HG03540/assemblies/release2/annotation/cat/HG03540_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03540_pat_hprc_r2_v1.0.1,113145869
+HG01258,2,s3://human-pangenomics/working/HPRC/HG01258/assemblies/release2/annotation/cat/HG01258_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01258_mat_hprc_r2_v1.0.1,113708599
+NA20809,1,s3://human-pangenomics/working/HPRC/NA20809/assemblies/release2/annotation/cat/NA20809_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA20809_hap1_hprc_r2_v1.0.1,107386626
+HG02109,2,s3://human-pangenomics/working/HPRC_PLUS/HG02109/assemblies/release2/annotation/cat/HG02109_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02109_mat_hprc_r2_v1.0.1,103889003
+HG04115,2,s3://human-pangenomics/working/HPRC/HG04115/assemblies/release2/annotation/cat/HG04115_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG04115_mat_hprc_r2_v1.0.1,111736559
+NA21093,1,s3://human-pangenomics/working/HPRC/NA21093/assemblies/release2/annotation/cat/NA21093_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA21093_hap1_hprc_r2_v1.0.1,108515359
+HG02004,2,s3://human-pangenomics/working/HPRC/HG02004/assemblies/release2/annotation/cat/HG02004_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02004_mat_hprc_r2_v1.0.1,110847933
+HG00133,2,s3://human-pangenomics/working/HPRC/HG00133/assemblies/release2/annotation/cat/HG00133_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00133_hap2_hprc_r2_v1.0.1,111549817
+HG01784,1,s3://human-pangenomics/working/HPRC/HG01784/assemblies/release2/annotation/cat/HG01784_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01784_hap1_hprc_r2_v1.0.1,112239333
+HG02132,1,s3://human-pangenomics/working/HPRC/HG02132/assemblies/release2/annotation/cat/HG02132_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02132_pat_hprc_r2_v1.0.1,107310220
+HG01952,2,s3://human-pangenomics/working/HPRC/HG01952/assemblies/release2/annotation/cat/HG01952_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01952_mat_hprc_r2_v1.0.1,111028815
+HG00639,2,s3://human-pangenomics/working/HPRC/HG00639/assemblies/release2/annotation/cat/HG00639_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00639_mat_hprc_r2_v1.0.1,111655546
+HG03471,1,s3://human-pangenomics/working/HPRC/HG03471/assemblies/release2/annotation/cat/HG03471_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03471_hap1_hprc_r2_v1.0.1,101188558
+NA19776,2,s3://human-pangenomics/working/HPRC/NA19776/assemblies/release2/annotation/cat/NA19776_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA19776_hap2_hprc_r2_v1.0.1,111201052
+HG01175,1,s3://human-pangenomics/working/HPRC/HG01175/assemblies/release2/annotation/cat/HG01175_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01175_pat_hprc_r2_v1.0.1,110808583
+HG02735,2,s3://human-pangenomics/working/HPRC/HG02735/assemblies/release2/annotation/cat/HG02735_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02735_mat_hprc_r2_v1.0.1,111361499
+HG02698,2,s3://human-pangenomics/working/HPRC/HG02698/assemblies/release2/annotation/cat/HG02698_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02698_mat_hprc_r2_v1.0.1,111780308
+HG02257,2,s3://human-pangenomics/working/HPRC/HG02257/assemblies/release2/annotation/cat/HG02257_mat_hprc_r2_v1.1.0_cat_v1.3.gff3.gz,CAT Genes,2,HG02257_mat_hprc_r2_v1.1.0,114105951
+HG03834,2,s3://human-pangenomics/working/HPRC/HG03834/assemblies/release2/annotation/cat/HG03834_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03834_mat_hprc_r2_v1.0.1,111116999
+HG01109,1,s3://human-pangenomics/working/HPRC_PLUS/HG01109/assemblies/release2/annotation/cat/HG01109_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01109_pat_hprc_r2_v1.0.1,101053890
+NA18945,2,s3://human-pangenomics/working/HPP/NA18945/assemblies/release2/annotation/cat/NA18945_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18945_hap2_hprc_r2_v1.0.1,103918709
+NA18976,1,s3://human-pangenomics/working/HPRC/NA18976/assemblies/release2/annotation/cat/NA18976_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18976_hap1_hprc_r2_v1.0.1,110742336
+HG03225,2,s3://human-pangenomics/working/HPRC/HG03225/assemblies/release2/annotation/cat/HG03225_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03225_hap2_hprc_r2_v1.0.1,114324293
+NA20762,2,s3://human-pangenomics/working/HPRC/NA20762/assemblies/release2/annotation/cat/NA20762_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA20762_hap2_hprc_r2_v1.0.1,111409723
+HG02040,1,s3://human-pangenomics/working/HPRC/HG02040/assemblies/release2/annotation/cat/HG02040_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02040_hap1_hprc_r2_v1.0.1,109552316
+NA20870,1,s3://human-pangenomics/working/HPRC/NA20870/assemblies/release2/annotation/cat/NA20870_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA20870_hap1_hprc_r2_v1.0.1,108557506
+HG03017,1,s3://human-pangenomics/working/HPRC/HG03017/assemblies/release2/annotation/cat/HG03017_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03017_pat_hprc_r2_v1.0.1,107990511
+NA18974,1,s3://human-pangenomics/working/HPRC/NA18974/assemblies/release2/annotation/cat/NA18974_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18974_hap1_hprc_r2_v1.0.1,108474680
+HG00438,2,s3://human-pangenomics/working/HPRC/HG00438/assemblies/release2/annotation/cat/HG00438_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00438_mat_hprc_r2_v1.0.1,111462142
+HG00323,1,s3://human-pangenomics/working/HPRC/HG00323/assemblies/release2/annotation/cat/HG00323_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00323_hap1_hprc_r2_v1.0.1,111370015
+NA21110,2,s3://human-pangenomics/working/HPRC/NA21110/assemblies/release2/annotation/cat/NA21110_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA21110_hap2_hprc_r2_v1.0.1,111056327
+HG02080,1,s3://human-pangenomics/working/HPRC_PLUS/HG02080/assemblies/release2/annotation/cat/HG02080_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02080_pat_hprc_r2_v1.0.1,104054814
+HG00290,1,s3://human-pangenomics/working/HPRC/HG00290/assemblies/release2/annotation/cat/HG00290_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00290_hap1_hprc_r2_v1.0.1,108387748
+NA20806,2,s3://human-pangenomics/working/HPRC/NA20806/assemblies/release2/annotation/cat/NA20806_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA20806_hap2_hprc_r2_v1.0.1,110997767
+HG01981,1,s3://human-pangenomics/working/HPRC/HG01981/assemblies/release2/annotation/cat/HG01981_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01981_pat_hprc_r2_v1.0.1,112241656
+HG01106,2,s3://human-pangenomics/working/HPRC/HG01106/assemblies/release2/annotation/cat/HG01106_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01106_mat_hprc_r2_v1.0.1,110746421
+HG00253,1,s3://human-pangenomics/working/HPRC/HG00253/assemblies/release2/annotation/cat/HG00253_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00253_hap1_hprc_r2_v1.0.1,110402589
+HG04157,1,s3://human-pangenomics/working/HPRC/HG04157/assemblies/release2/annotation/cat/HG04157_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG04157_pat_hprc_r2_v1.0.1,109240460
+HG02723,1,s3://human-pangenomics/working/HPRC_PLUS/HG02723/assemblies/release2/annotation/cat/HG02723_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02723_pat_hprc_r2_v1.0.1,104120797
+HG04115,1,s3://human-pangenomics/working/HPRC/HG04115/assemblies/release2/annotation/cat/HG04115_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG04115_pat_hprc_r2_v1.0.1,108721571
+NA20129,2,s3://human-pangenomics/working/HPRC_PLUS/NA20129/assemblies/release2/annotation/cat/NA20129_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA20129_mat_hprc_r2_v1.0.1,103967740
+NA18959,2,s3://human-pangenomics/working/HPP/NA18959/assemblies/release2/annotation/cat/NA18959_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18959_hap2_hprc_r2_v1.0.1,104330358
+HG02293,2,s3://human-pangenomics/working/HPRC/HG02293/assemblies/release2/annotation/cat/HG02293_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02293_mat_hprc_r2_v1.0.1,110960920
+HG01346,2,s3://human-pangenomics/working/HPRC/HG01346/assemblies/release2/annotation/cat/HG01346_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01346_mat_hprc_r2_v1.0.1,113445954
+NA20809,2,s3://human-pangenomics/working/HPRC/NA20809/assemblies/release2/annotation/cat/NA20809_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA20809_hap2_hprc_r2_v1.0.1,110109634
+HG01975,1,s3://human-pangenomics/working/HPRC/HG01975/assemblies/release2/annotation/cat/HG01975_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01975_pat_hprc_r2_v1.0.1,112591220
+NA20282,2,s3://human-pangenomics/working/HPRC/NA20282/assemblies/release2/annotation/cat/NA20282_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA20282_hap2_hprc_r2_v1.0.1,109304505
+NA18983,2,s3://human-pangenomics/working/HPRC/NA18983/assemblies/release2/annotation/cat/NA18983_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18983_hap2_hprc_r2_v1.0.1,110942088
+NA21110,1,s3://human-pangenomics/working/HPRC/NA21110/assemblies/release2/annotation/cat/NA21110_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA21110_hap1_hprc_r2_v1.0.1,112664430
+HG03270,2,s3://human-pangenomics/working/HPRC/HG03270/assemblies/release2/annotation/cat/HG03270_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03270_hap2_hprc_r2_v1.0.1,111110065
+NA20799,1,s3://human-pangenomics/working/HPRC/NA20799/assemblies/release2/annotation/cat/NA20799_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA20799_hap1_hprc_r2_v1.0.1,112012722
+HG01978,2,s3://human-pangenomics/working/HPRC/HG01978/assemblies/release2/annotation/cat/HG01978_mat_hprc_r2_v1.1.0_cat_v1.3.gff3.gz,CAT Genes,2,HG01978_mat_hprc_r2_v1.1.0,110691899
+HG02486,2,s3://human-pangenomics/working/HPRC/HG02486/assemblies/release2/annotation/cat/HG02486_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02486_mat_hprc_r2_v1.0.1,104051490
+HG03579,2,s3://human-pangenomics/working/HPRC/HG03579/assemblies/release2/annotation/cat/HG03579_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03579_mat_hprc_r2_v1.0.1,110742387
+NA18970,1,s3://human-pangenomics/working/HPP/NA18970/assemblies/release2/annotation/cat/NA18970_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18970_hap1_hprc_r2_v1.0.1,107980844
+HG00673,1,s3://human-pangenomics/working/HPRC/HG00673/assemblies/release2/annotation/cat/HG00673_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00673_pat_hprc_r2_v1.0.1,107750976
+HG00232,1,s3://human-pangenomics/working/HPRC/HG00232/assemblies/release2/annotation/cat/HG00232_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00232_hap1_hprc_r2_v1.0.1,111745408
+HG02886,2,s3://human-pangenomics/working/HPRC/HG02886/assemblies/release2/annotation/cat/HG02886_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02886_mat_hprc_r2_v1.0.1,112657596
+HG01940,1,s3://human-pangenomics/working/HPRC/HG01940/assemblies/release2/annotation/cat/HG01940_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01940_pat_hprc_r2_v1.0.1,111963689
+HG03470,1,s3://human-pangenomics/working/HPRC/HG03470/assemblies/release2/annotation/cat/HG03470_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03470_hap1_hprc_r2_v1.0.1,112389525
+NA18971,2,s3://human-pangenomics/working/HPRC/NA18971/assemblies/release2/annotation/cat/NA18971_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18971_hap2_hprc_r2_v1.0.1,110654906
+HG01167,1,s3://human-pangenomics/working/HPRC/HG01167/assemblies/release2/annotation/cat/HG01167_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01167_hap1_hprc_r2_v1.0.1,108243650
+HG02155,1,s3://human-pangenomics/working/HPRC/HG02155/assemblies/release2/annotation/cat/HG02155_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02155_hap1_hprc_r2_v1.0.1,112117698
+NA19240,1,s3://human-pangenomics/working/HPRC_PLUS/NA19240/assemblies/release2/annotation/cat/NA19240_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA19240_pat_hprc_r2_v1.0.1,104125921
+NA19443,1,s3://human-pangenomics/working/HPRC/NA19443/assemblies/release2/annotation/cat/NA19443_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA19443_hap1_hprc_r2_v1.0.1,108560847
+HG01074,1,s3://human-pangenomics/working/HPRC/HG01074/assemblies/release2/annotation/cat/HG01074_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01074_pat_hprc_r2_v1.0.1,107594118
+HG02178,1,s3://human-pangenomics/working/HPRC/HG02178/assemblies/release2/annotation/cat/HG02178_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02178_hap1_hprc_r2_v1.0.1,111547503
+HG00706,2,s3://human-pangenomics/working/HPRC/HG00706/assemblies/release2/annotation/cat/HG00706_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00706_mat_hprc_r2_v1.0.1,112178610
+HG01261,1,s3://human-pangenomics/working/HPRC/HG01261/assemblies/release2/annotation/cat/HG01261_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01261_pat_hprc_r2_v1.0.1,107782627
+HG02723,2,s3://human-pangenomics/working/HPRC_PLUS/HG02723/assemblies/release2/annotation/cat/HG02723_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02723_mat_hprc_r2_v1.0.1,104189137
+HG02976,2,s3://human-pangenomics/working/HPRC/HG02976/assemblies/release2/annotation/cat/HG02976_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02976_hap2_hprc_r2_v1.0.1,116339121
+HG01978,1,s3://human-pangenomics/working/HPRC/HG01978/assemblies/release2/annotation/cat/HG01978_pat_hprc_r2_v1.1.0_cat_v1.3.gff3.gz,CAT Genes,2,HG01978_pat_hprc_r2_v1.1.0,110957332
+NA20850,2,s3://human-pangenomics/working/HPRC/NA20850/assemblies/release2/annotation/cat/NA20850_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA20850_hap2_hprc_r2_v1.0.1,110863774
+HG02074,2,s3://human-pangenomics/working/HPRC/HG02074/assemblies/release2/annotation/cat/HG02074_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02074_mat_hprc_r2_v1.0.1,110908108
+HG02391,1,s3://human-pangenomics/working/HPRC/HG02391/assemblies/release2/annotation/cat/HG02391_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02391_hap1_hprc_r2_v1.0.1,109083009
+HG02514,2,s3://human-pangenomics/working/HPRC/HG02514/assemblies/release2/annotation/cat/HG02514_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02514_mat_hprc_r2_v1.0.1,111332451
+HG02717,2,s3://human-pangenomics/working/HPRC/HG02717/assemblies/release2/annotation/cat/HG02717_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02717_mat_hprc_r2_v1.0.1,112277344
+HG01884,2,s3://human-pangenomics/working/HPRC/HG01884/assemblies/release2/annotation/cat/HG01884_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01884_mat_hprc_r2_v1.0.1,111252828
+HG02129,2,s3://human-pangenomics/working/HPRC/HG02129/assemblies/release2/annotation/cat/HG02129_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02129_mat_hprc_r2_v1.0.1,112286995
+NA20503,2,s3://human-pangenomics/working/HPRC/NA20503/assemblies/release2/annotation/cat/NA20503_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA20503_hap2_hprc_r2_v1.0.1,110537012
+HG03710,2,s3://human-pangenomics/working/HPRC/HG03710/assemblies/release2/annotation/cat/HG03710_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03710_mat_hprc_r2_v1.0.1,112016320
+HG01891,2,s3://human-pangenomics/working/HPRC/HG01891/assemblies/release2/annotation/cat/HG01891_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01891_mat_hprc_r2_v1.0.1,114636027
+NA19036,2,s3://human-pangenomics/working/HPRC/NA19036/assemblies/release2/annotation/cat/NA19036_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA19036_hap2_hprc_r2_v1.0.1,111550180
+HG01255,1,s3://human-pangenomics/working/HPRC/HG01255/assemblies/release2/annotation/cat/HG01255_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01255_pat_hprc_r2_v1.0.1,108451521
+HG00323,2,s3://human-pangenomics/working/HPRC/HG00323/assemblies/release2/annotation/cat/HG00323_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00323_hap2_hprc_r2_v1.0.1,111085666
+HG01081,2,s3://human-pangenomics/working/HPRC/HG01081/assemblies/release2/annotation/cat/HG01081_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01081_mat_hprc_r2_v1.0.1,111557241
+HG01884,1,s3://human-pangenomics/working/HPRC/HG01884/assemblies/release2/annotation/cat/HG01884_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01884_pat_hprc_r2_v1.0.1,111387413
+NA20762,1,s3://human-pangenomics/working/HPRC/NA20762/assemblies/release2/annotation/cat/NA20762_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA20762_hap1_hprc_r2_v1.0.1,107151480
+NA19338,1,s3://human-pangenomics/working/HPRC/NA19338/assemblies/release2/annotation/cat/NA19338_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA19338_hap1_hprc_r2_v1.0.1,113593730
+HG04187,2,s3://human-pangenomics/working/HPRC/HG04187/assemblies/release2/annotation/cat/HG04187_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG04187_mat_hprc_r2_v1.0.1,110893182
+HG02300,1,s3://human-pangenomics/working/HPRC/HG02300/assemblies/release2/annotation/cat/HG02300_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02300_pat_hprc_r2_v1.0.1,111444019
+HG03688,1,s3://human-pangenomics/working/HPRC/HG03688/assemblies/release2/annotation/cat/HG03688_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03688_pat_hprc_r2_v1.0.1,108560005
+NA18620,1,s3://human-pangenomics/working/HPRC/NA18620/assemblies/release2/annotation/cat/NA18620_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18620_hap1_hprc_r2_v1.0.1,109074173
+HG02178,2,s3://human-pangenomics/working/HPRC/HG02178/assemblies/release2/annotation/cat/HG02178_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02178_hap2_hprc_r2_v1.0.1,112015368
+HG04204,1,s3://human-pangenomics/working/HPRC/HG04204/assemblies/release2/annotation/cat/HG04204_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG04204_pat_hprc_r2_v1.0.1,107984588
+HG00272,1,s3://human-pangenomics/working/HPRC/HG00272/assemblies/release2/annotation/cat/HG00272_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00272_hap1_hprc_r2_v1.0.1,110846347
+HG02145,2,s3://human-pangenomics/working/HPRC_PLUS/HG02145/assemblies/release2/annotation/cat/HG02145_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02145_mat_hprc_r2_v1.0.1,104060485
+NA18940,1,s3://human-pangenomics/working/HPP/NA18940/assemblies/release2/annotation/cat/NA18940_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18940_hap1_hprc_r2_v1.0.1,100702586
+NA19087,1,s3://human-pangenomics/working/HPRC/NA19087/assemblies/release2/annotation/cat/NA19087_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA19087_hap1_hprc_r2_v1.0.1,112694824
+HG03688,2,s3://human-pangenomics/working/HPRC/HG03688/assemblies/release2/annotation/cat/HG03688_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03688_mat_hprc_r2_v1.0.1,111755246
+NA18940,2,s3://human-pangenomics/working/HPP/NA18940/assemblies/release2/annotation/cat/NA18940_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18940_hap2_hprc_r2_v1.0.1,103481518
+HG00741,2,s3://human-pangenomics/working/HPRC/HG00741/assemblies/release2/annotation/cat/HG00741_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00741_mat_hprc_r2_v1.0.1,110399932
+HG00320,1,s3://human-pangenomics/working/HPRC/HG00320/assemblies/release2/annotation/cat/HG00320_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00320_hap1_hprc_r2_v1.0.1,111004800
+HG00408,2,s3://human-pangenomics/working/HPRC/HG00408/assemblies/release2/annotation/cat/HG00408_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00408_mat_hprc_r2_v1.0.1,112675562
+HG03098,2,s3://human-pangenomics/working/HPRC_PLUS/HG03098/assemblies/release2/annotation/cat/HG03098_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03098_mat_hprc_r2_v1.0.1,104189917
+HG03195,2,s3://human-pangenomics/working/HPRC/HG03195/assemblies/release2/annotation/cat/HG03195_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03195_hap2_hprc_r2_v1.0.1,112473783
+NA20827,1,s3://human-pangenomics/working/HPRC/NA20827/assemblies/release2/annotation/cat/NA20827_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA20827_hap1_hprc_r2_v1.0.1,107564429
+HG00642,1,s3://human-pangenomics/working/HPRC/HG00642/assemblies/release2/annotation/cat/HG00642_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00642_pat_hprc_r2_v1.0.1,109063519
+HG00320,2,s3://human-pangenomics/working/HPRC/HG00320/assemblies/release2/annotation/cat/HG00320_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00320_hap2_hprc_r2_v1.0.1,110784669
+HG00126,1,s3://human-pangenomics/working/HPRC/HG00126/assemblies/release2/annotation/cat/HG00126_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00126_hap1_hprc_r2_v1.0.1,108823951
+HG02523,1,s3://human-pangenomics/working/HPRC/HG02523/assemblies/release2/annotation/cat/HG02523_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02523_pat_hprc_r2_v1.0.1,110432594
+HG00321,1,s3://human-pangenomics/working/HPRC/HG00321/assemblies/release2/annotation/cat/HG00321_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00321_hap1_hprc_r2_v1.0.1,100890678
+HG01150,2,s3://human-pangenomics/working/HPRC/HG01150/assemblies/release2/annotation/cat/HG01150_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01150_mat_hprc_r2_v1.0.1,111782577
+HG00642,2,s3://human-pangenomics/working/HPRC/HG00642/assemblies/release2/annotation/cat/HG00642_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00642_mat_hprc_r2_v1.0.1,112044332
+HG02735,1,s3://human-pangenomics/working/HPRC/HG02735/assemblies/release2/annotation/cat/HG02735_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02735_pat_hprc_r2_v1.0.1,107891483
+HG00673,2,s3://human-pangenomics/working/HPRC/HG00673/assemblies/release2/annotation/cat/HG00673_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00673_mat_hprc_r2_v1.0.1,110121326
+HG03050,2,s3://human-pangenomics/working/HPRC/HG03050/assemblies/release2/annotation/cat/HG03050_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03050_mat_hprc_r2_v1.0.1,112942703
+NA19700,1,s3://human-pangenomics/working/HPRC/NA19700/assemblies/release2/annotation/cat/NA19700_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA19700_hap1_hprc_r2_v1.0.1,109031750
+HG00621,1,s3://human-pangenomics/working/HPRC/HG00621/assemblies/release2/annotation/cat/HG00621_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00621_pat_hprc_r2_v1.0.1,107983231
+HG04199,2,s3://human-pangenomics/working/HPRC/HG04199/assemblies/release2/annotation/cat/HG04199_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG04199_mat_hprc_r2_v1.0.1,111757695
+HG01928,1,s3://human-pangenomics/working/HPRC/HG01928/assemblies/release2/annotation/cat/HG01928_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01928_pat_hprc_r2_v1.0.1,107952643
+HG03521,2,s3://human-pangenomics/working/HPRC/HG03521/assemblies/release2/annotation/cat/HG03521_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03521_hap2_hprc_r2_v1.0.1,111456068
+HG02155,2,s3://human-pangenomics/working/HPRC/HG02155/assemblies/release2/annotation/cat/HG02155_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02155_hap2_hprc_r2_v1.0.1,112038857
+NA18982,1,s3://human-pangenomics/working/HPP/NA18982/assemblies/release2/annotation/cat/NA18982_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18982_hap1_hprc_r2_v1.0.1,100926554
+HG00423,1,s3://human-pangenomics/working/HPRC/HG00423/assemblies/release2/annotation/cat/HG00423_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00423_pat_hprc_r2_v1.0.1,110408896
+HG01891,1,s3://human-pangenomics/working/HPRC/HG01891/assemblies/release2/annotation/cat/HG01891_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01891_pat_hprc_r2_v1.0.1,114344126
+HG02841,1,s3://human-pangenomics/working/HPRC/HG02841/assemblies/release2/annotation/cat/HG02841_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02841_pat_hprc_r2_v1.0.1,111724841
+HG00544,1,s3://human-pangenomics/working/HPRC/HG00544/assemblies/release2/annotation/cat/HG00544_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00544_pat_hprc_r2_v1.0.1,110912263
+HG01496,2,s3://human-pangenomics/working/HPRC/HG01496/assemblies/release2/annotation/cat/HG01496_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01496_mat_hprc_r2_v1.0.1,111927377
+HG00329,2,s3://human-pangenomics/working/HPRC/HG00329/assemblies/release2/annotation/cat/HG00329_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00329_hap2_hprc_r2_v1.0.1,110850488
+NA18952,1,s3://human-pangenomics/working/HPRC/NA18952/assemblies/release2/annotation/cat/NA18952_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18952_hap1_hprc_r2_v1.0.1,108539839
+HG00272,2,s3://human-pangenomics/working/HPRC/HG00272/assemblies/release2/annotation/cat/HG00272_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00272_hap2_hprc_r2_v1.0.1,111021802
+NA20282,1,s3://human-pangenomics/working/HPRC/NA20282/assemblies/release2/annotation/cat/NA20282_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA20282_hap1_hprc_r2_v1.0.1,109761381
+HG00232,2,s3://human-pangenomics/working/HPRC/HG00232/assemblies/release2/annotation/cat/HG00232_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00232_hap2_hprc_r2_v1.0.1,111689854
+HG02071,2,s3://human-pangenomics/working/HPRC/HG02071/assemblies/release2/annotation/cat/HG02071_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02071_mat_hprc_r2_v1.0.1,111489673
+NA18906,1,s3://human-pangenomics/working/HPRC_PLUS/NA18906/assemblies/release2/annotation/cat/NA18906_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18906_pat_hprc_r2_v1.0.1,104402853
+HG02630,1,s3://human-pangenomics/working/HPRC/HG02630/assemblies/release2/annotation/cat/HG02630_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02630_pat_hprc_r2_v1.0.1,112342794
+NA18948,2,s3://human-pangenomics/working/HPP/NA18948/assemblies/release2/annotation/cat/NA18948_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18948_hap2_hprc_r2_v1.0.1,104132831
+NA19682,1,s3://human-pangenomics/working/HPRC/NA19682/assemblies/release2/annotation/cat/NA19682_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA19682_hap1_hprc_r2_v1.0.1,107961194
+HG02083,1,s3://human-pangenomics/working/HPRC/HG02083/assemblies/release2/annotation/cat/HG02083_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02083_pat_hprc_r2_v1.0.1,108430734
+HG02258,1,s3://human-pangenomics/working/HPRC/HG02258/assemblies/release2/annotation/cat/HG02258_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02258_pat_hprc_r2_v1.0.1,109501753
+HG00344,1,s3://human-pangenomics/working/HPRC/HG00344/assemblies/release2/annotation/cat/HG00344_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00344_hap1_hprc_r2_v1.0.1,110891532
+NA19185,1,s3://human-pangenomics/working/HPRC/NA19185/assemblies/release2/annotation/cat/NA19185_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA19185_hap1_hprc_r2_v1.0.1,112799141
+HG01255,2,s3://human-pangenomics/working/HPRC/HG01255/assemblies/release2/annotation/cat/HG01255_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01255_mat_hprc_r2_v1.0.1,111711127
+HG01123,2,s3://human-pangenomics/working/HPRC/HG01123/assemblies/release2/annotation/cat/HG01123_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01123_mat_hprc_r2_v1.0.1,103810611
+NA18943,2,s3://human-pangenomics/working/HPP/NA18943/assemblies/release2/annotation/cat/NA18943_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18943_hap2_hprc_r2_v1.0.1,104025609
+HG01252,1,s3://human-pangenomics/working/HPRC/HG01252/assemblies/release2/annotation/cat/HG01252_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01252_pat_hprc_r2_v1.0.1,108688298
+HG02809,1,s3://human-pangenomics/working/HPRC/HG02809/assemblies/release2/annotation/cat/HG02809_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02809_pat_hprc_r2_v1.0.1,112346497
+NA18879,1,s3://human-pangenomics/working/HPRC/NA18879/assemblies/release2/annotation/cat/NA18879_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18879_hap1_hprc_r2_v1.0.1,107865214
+HG01969,2,s3://human-pangenomics/working/HPRC/HG01969/assemblies/release2/annotation/cat/HG01969_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01969_mat_hprc_r2_v1.0.1,110824559
+HG00438,1,s3://human-pangenomics/working/HPRC/HG00438/assemblies/release2/annotation/cat/HG00438_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00438_pat_hprc_r2_v1.0.1,111252038
+HG03369,1,s3://human-pangenomics/working/HPRC/HG03369/assemblies/release2/annotation/cat/HG03369_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03369_hap1_hprc_r2_v1.0.1,111062520
+NA21144,1,s3://human-pangenomics/working/HPRC/NA21144/assemblies/release2/annotation/cat/NA21144_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA21144_hap1_hprc_r2_v1.0.1,111013122
+NA18747,2,s3://human-pangenomics/working/HPRC/NA18747/assemblies/release2/annotation/cat/NA18747_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18747_hap2_hprc_r2_v1.0.1,103078173
+NA18959,1,s3://human-pangenomics/working/HPP/NA18959/assemblies/release2/annotation/cat/NA18959_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18959_hap1_hprc_r2_v1.0.1,100939505
+HG03239,2,s3://human-pangenomics/working/HPRC/HG03239/assemblies/release2/annotation/cat/HG03239_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03239_mat_hprc_r2_v1.0.1,111390376
+HG01530,1,s3://human-pangenomics/working/HPRC/HG01530/assemblies/release2/annotation/cat/HG01530_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01530_hap1_hprc_r2_v1.0.1,108863782
+HG03486,1,s3://human-pangenomics/working/HPRC_PLUS/HG03486/assemblies/release2/annotation/cat/HG03486_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03486_pat_hprc_r2_v1.0.1,104276321
+HG06807,1,s3://human-pangenomics/working/HPRC/HG06807/assemblies/release2/annotation/cat/HG06807_pat_v1_cat_v1.3.gff3.gz,CAT Genes,2,HG06807_pat_v1,103758797
+HG02717,1,s3://human-pangenomics/working/HPRC/HG02717/assemblies/release2/annotation/cat/HG02717_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02717_pat_hprc_r2_v1.0.1,109331134
+HG01071,1,s3://human-pangenomics/working/HPRC/HG01071/assemblies/release2/annotation/cat/HG01071_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01071_pat_hprc_r2_v1.0.1,110711290
+HG01346,1,s3://human-pangenomics/working/HPRC/HG01346/assemblies/release2/annotation/cat/HG01346_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01346_pat_hprc_r2_v1.0.1,113681408
+NA19087,2,s3://human-pangenomics/working/HPRC/NA19087/assemblies/release2/annotation/cat/NA19087_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA19087_hap2_hprc_r2_v1.0.1,112193030
+HG00658,2,s3://human-pangenomics/working/HPRC/HG00658/assemblies/release2/annotation/cat/HG00658_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00658_mat_hprc_r2_v1.0.1,111637485
+HG03704,2,s3://human-pangenomics/working/HPRC/HG03704/assemblies/release2/annotation/cat/HG03704_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03704_mat_hprc_r2_v1.0.1,111550763
+NA18906,2,s3://human-pangenomics/working/HPRC_PLUS/NA18906/assemblies/release2/annotation/cat/NA18906_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18906_mat_hprc_r2_v1.0.1,104046408
+NA20346,2,s3://human-pangenomics/working/HPRC/NA20346/assemblies/release2/annotation/cat/NA20346_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA20346_hap2_hprc_r2_v1.0.1,111155045
+NA18570,2,s3://human-pangenomics/working/HPRC/NA18570/assemblies/release2/annotation/cat/NA18570_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18570_hap2_hprc_r2_v1.0.1,111960114
+HG03225,1,s3://human-pangenomics/working/HPRC/HG03225/assemblies/release2/annotation/cat/HG03225_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03225_hap1_hprc_r2_v1.0.1,110963979
+HG02583,2,s3://human-pangenomics/working/HPRC/HG02583/assemblies/release2/annotation/cat/HG02583_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02583_hap2_hprc_r2_v1.0.1,111275952
+HG02165,1,s3://human-pangenomics/working/HPRC/HG02165/assemblies/release2/annotation/cat/HG02165_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02165_hap1_hprc_r2_v1.0.1,110634028
+HG01192,1,s3://human-pangenomics/working/HPRC/HG01192/assemblies/release2/annotation/cat/HG01192_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01192_pat_hprc_r2_v1.0.1,108156531
+NA21106,2,s3://human-pangenomics/working/HPRC/NA21106/assemblies/release2/annotation/cat/NA21106_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA21106_hap2_hprc_r2_v1.0.1,113311206
+HG01258,1,s3://human-pangenomics/working/HPRC/HG01258/assemblies/release2/annotation/cat/HG01258_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01258_pat_hprc_r2_v1.0.1,110230904
+HG03784,2,s3://human-pangenomics/working/HPRC/HG03784/assemblies/release2/annotation/cat/HG03784_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03784_hap2_hprc_r2_v1.0.1,110949202
+HG00738,2,s3://human-pangenomics/working/HPRC/HG00738/assemblies/release2/annotation/cat/HG00738_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00738_mat_hprc_r2_v1.0.1,111285455
+HG01175,2,s3://human-pangenomics/working/HPRC/HG01175/assemblies/release2/annotation/cat/HG01175_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01175_mat_hprc_r2_v1.0.1,110968183
+HG03195,1,s3://human-pangenomics/working/HPRC/HG03195/assemblies/release2/annotation/cat/HG03195_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03195_hap1_hprc_r2_v1.0.1,112378988
+HG02015,2,s3://human-pangenomics/working/HPRC/HG02015/assemblies/release2/annotation/cat/HG02015_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02015_mat_hprc_r2_v1.0.1,111758999
+HG03583,1,s3://human-pangenomics/working/HPRC/HG03583/assemblies/release2/annotation/cat/HG03583_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03583_hap1_hprc_r2_v1.0.1,111908860
+NA19338,2,s3://human-pangenomics/working/HPRC/NA19338/assemblies/release2/annotation/cat/NA19338_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA19338_hap2_hprc_r2_v1.0.1,113742505
+HG02135,2,s3://human-pangenomics/working/HPRC/HG02135/assemblies/release2/annotation/cat/HG02135_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02135_mat_hprc_r2_v1.0.1,110251742
+HG03471,2,s3://human-pangenomics/working/HPRC/HG03471/assemblies/release2/annotation/cat/HG03471_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03471_hap2_hprc_r2_v1.0.1,104016825
+HG03270,1,s3://human-pangenomics/working/HPRC/HG03270/assemblies/release2/annotation/cat/HG03270_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03270_hap1_hprc_r2_v1.0.1,111041608
+HG00133,1,s3://human-pangenomics/working/HPRC/HG00133/assemblies/release2/annotation/cat/HG00133_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00133_hap1_hprc_r2_v1.0.1,111527661
+HG03209,1,s3://human-pangenomics/working/HPRC/HG03209/assemblies/release2/annotation/cat/HG03209_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03209_hap1_hprc_r2_v1.0.1,108918999
+HG00706,1,s3://human-pangenomics/working/HPRC/HG00706/assemblies/release2/annotation/cat/HG00706_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00706_pat_hprc_r2_v1.0.1,109169885
+HG01786,2,s3://human-pangenomics/working/HPRC/HG01786/assemblies/release2/annotation/cat/HG01786_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01786_hap2_hprc_r2_v1.0.1,111478126
+HG00597,2,s3://human-pangenomics/working/HPRC/HG00597/assemblies/release2/annotation/cat/HG00597_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00597_mat_hprc_r2_v1.0.1,112223653
+NA18522,2,s3://human-pangenomics/working/HPRC/NA18522/assemblies/release2/annotation/cat/NA18522_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18522_hap2_hprc_r2_v1.0.1,113236508
+NA18960,1,s3://human-pangenomics/working/HPP/NA18960/assemblies/release2/annotation/cat/NA18960_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18960_hap1_hprc_r2_v1.0.1,101157294
+HG02559,1,s3://human-pangenomics/working/HPRC/HG02559/assemblies/release2/annotation/cat/HG02559_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02559_pat_hprc_r2_v1.0.1,104288467
+HG00350,1,s3://human-pangenomics/working/HPRC/HG00350/assemblies/release2/annotation/cat/HG00350_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00350_hap1_hprc_r2_v1.0.1,110831719
+NA21093,2,s3://human-pangenomics/working/HPRC/NA21093/assemblies/release2/annotation/cat/NA21093_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA21093_hap2_hprc_r2_v1.0.1,111682759
+HG01934,1,s3://human-pangenomics/working/HPRC/HG01934/assemblies/release2/annotation/cat/HG01934_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01934_pat_hprc_r2_v1.0.1,108548855
+HG00097,2,s3://human-pangenomics/working/HPRC/HG00097/assemblies/release2/annotation/cat/HG00097_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00097_hap2_hprc_r2_v1.0.1,110616252
+NA19909,2,s3://human-pangenomics/working/HPRC/NA19909/assemblies/release2/annotation/cat/NA19909_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA19909_hap2_hprc_r2_v1.0.1,110810198
+NA20827,2,s3://human-pangenomics/working/HPRC/NA20827/assemblies/release2/annotation/cat/NA20827_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA20827_hap2_hprc_r2_v1.0.1,110718586
+HG01109,2,s3://human-pangenomics/working/HPRC_PLUS/HG01109/assemblies/release2/annotation/cat/HG01109_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01109_mat_hprc_r2_v1.0.1,104124905
+HG00128,1,s3://human-pangenomics/working/HPRC/HG00128/assemblies/release2/annotation/cat/HG00128_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00128_hap1_hprc_r2_v1.0.1,111006252
+HG02074,1,s3://human-pangenomics/working/HPRC/HG02074/assemblies/release2/annotation/cat/HG02074_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02074_pat_hprc_r2_v1.0.1,108238828
+HG02027,1,s3://human-pangenomics/working/HPRC/HG02027/assemblies/release2/annotation/cat/HG02027_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02027_pat_hprc_r2_v1.0.1,106769556
+NA18970,2,s3://human-pangenomics/working/HPP/NA18970/assemblies/release2/annotation/cat/NA18970_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18970_hap2_hprc_r2_v1.0.1,111715769
+NA19043,2,s3://human-pangenomics/working/HPRC/NA19043/assemblies/release2/annotation/cat/NA19043_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA19043_hap2_hprc_r2_v1.0.1,111996125
+HG01358,1,s3://human-pangenomics/working/HPRC/HG01358/assemblies/release2/annotation/cat/HG01358_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01358_pat_hprc_r2_v1.0.1,109634093
+HG04187,1,s3://human-pangenomics/working/HPRC/HG04187/assemblies/release2/annotation/cat/HG04187_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG04187_pat_hprc_r2_v1.0.1,107718520
+HG02486,1,s3://human-pangenomics/working/HPRC/HG02486/assemblies/release2/annotation/cat/HG02486_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02486_pat_hprc_r2_v1.0.1,100924391
+HG01928,2,s3://human-pangenomics/working/HPRC/HG01928/assemblies/release2/annotation/cat/HG01928_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01928_mat_hprc_r2_v1.0.1,110940058
+HG02300,2,s3://human-pangenomics/working/HPRC/HG02300/assemblies/release2/annotation/cat/HG02300_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02300_mat_hprc_r2_v1.0.1,111371941
+NA19185,2,s3://human-pangenomics/working/HPRC/NA19185/assemblies/release2/annotation/cat/NA19185_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA19185_hap2_hprc_r2_v1.0.1,112735861
+HG00280,1,s3://human-pangenomics/working/HPRC/HG00280/assemblies/release2/annotation/cat/HG00280_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00280_hap1_hprc_r2_v1.0.1,109598074
+NA19909,1,s3://human-pangenomics/working/HPRC/NA19909/assemblies/release2/annotation/cat/NA19909_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA19909_hap1_hprc_r2_v1.0.1,110833042
+HG03041,1,s3://human-pangenomics/working/HPRC/HG03041/assemblies/release2/annotation/cat/HG03041_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03041_pat_hprc_r2_v1.0.1,112068991
+HG01074,2,s3://human-pangenomics/working/HPRC/HG01074/assemblies/release2/annotation/cat/HG01074_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01074_mat_hprc_r2_v1.0.1,110859058
+HG03139,2,s3://human-pangenomics/working/HPRC/HG03139/assemblies/release2/annotation/cat/HG03139_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03139_hap2_hprc_r2_v1.0.1,112865321
+HG01993,1,s3://human-pangenomics/working/HPRC/HG01993/assemblies/release2/annotation/cat/HG01993_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01993_pat_hprc_r2_v1.0.1,111754952
+NA19468,2,s3://human-pangenomics/working/HPRC/NA19468/assemblies/release2/annotation/cat/NA19468_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA19468_hap2_hprc_r2_v1.0.1,111952902
+HG02922,2,s3://human-pangenomics/working/HPRC/HG02922/assemblies/release2/annotation/cat/HG02922_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02922_hap2_hprc_r2_v1.0.1,112937018
+HG00280,2,s3://human-pangenomics/working/HPRC/HG00280/assemblies/release2/annotation/cat/HG00280_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00280_hap2_hprc_r2_v1.0.1,112542396
+HG00597,1,s3://human-pangenomics/working/HPRC/HG00597/assemblies/release2/annotation/cat/HG00597_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00597_pat_hprc_r2_v1.0.1,111626974
+NA21102,2,s3://human-pangenomics/working/HPRC/NA21102/assemblies/release2/annotation/cat/NA21102_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA21102_hap2_hprc_r2_v1.0.1,110131670
+NA21309,1,s3://human-pangenomics/working/HPRC_PLUS/NA21309/assemblies/release2/annotation/cat/NA21309_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA21309_pat_hprc_r2_v1.0.1,104149452
+HG03816,2,s3://human-pangenomics/working/HPRC/HG03816/assemblies/release2/annotation/cat/HG03816_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03816_mat_hprc_r2_v1.0.1,112063544
+NA20805,1,s3://human-pangenomics/working/HPRC/NA20805/assemblies/release2/annotation/cat/NA20805_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA20805_hap1_hprc_r2_v1.0.1,107755386
+HG03669,1,s3://human-pangenomics/working/HPRC/HG03669/assemblies/release2/annotation/cat/HG03669_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03669_pat_hprc_r2_v1.0.1,111733806
+HG02135,1,s3://human-pangenomics/working/HPRC/HG02135/assemblies/release2/annotation/cat/HG02135_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02135_pat_hprc_r2_v1.0.1,107432302
+HG02622,2,s3://human-pangenomics/working/HPRC/HG02622/assemblies/release2/annotation/cat/HG02622_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02622_mat_hprc_r2_v1.0.1,112834543
+HG03521,1,s3://human-pangenomics/working/HPRC/HG03521/assemblies/release2/annotation/cat/HG03521_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03521_hap1_hprc_r2_v1.0.1,107612954
+HG00621,2,s3://human-pangenomics/working/HPRC/HG00621/assemblies/release2/annotation/cat/HG00621_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00621_mat_hprc_r2_v1.0.1,111058443
+NA21144,2,s3://human-pangenomics/working/HPRC/NA21144/assemblies/release2/annotation/cat/NA21144_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA21144_hap2_hprc_r2_v1.0.1,110960010
+NA20129,1,s3://human-pangenomics/working/HPRC_PLUS/NA20129/assemblies/release2/annotation/cat/NA20129_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA20129_pat_hprc_r2_v1.0.1,104202813
+HG02572,1,s3://human-pangenomics/working/HPRC/HG02572/assemblies/release2/annotation/cat/HG02572_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02572_pat_hprc_r2_v1.0.1,108443070
+HG02056,1,s3://human-pangenomics/working/HPRC/HG02056/assemblies/release2/annotation/cat/HG02056_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02056_pat_hprc_r2_v1.0.1,109178984
+HG03130,1,s3://human-pangenomics/working/HPRC/HG03130/assemblies/release2/annotation/cat/HG03130_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03130_hap1_hprc_r2_v1.0.1,109610009
+HG00350,2,s3://human-pangenomics/working/HPRC/HG00350/assemblies/release2/annotation/cat/HG00350_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00350_hap2_hprc_r2_v1.0.1,111346040
+NA18608,2,s3://human-pangenomics/working/HPRC/NA18608/assemblies/release2/annotation/cat/NA18608_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18608_hap2_hprc_r2_v1.0.1,111491830
+NA21102,1,s3://human-pangenomics/working/HPRC/NA21102/assemblies/release2/annotation/cat/NA21102_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA21102_hap1_hprc_r2_v1.0.1,110008499
+HG02273,2,s3://human-pangenomics/working/HPRC/HG02273/assemblies/release2/annotation/cat/HG02273_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02273_hap2_hprc_r2_v1.0.1,112981609
+HG03017,2,s3://human-pangenomics/working/HPRC/HG03017/assemblies/release2/annotation/cat/HG03017_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03017_mat_hprc_r2_v1.0.1,111332879
+NA18879,2,s3://human-pangenomics/working/HPRC/NA18879/assemblies/release2/annotation/cat/NA18879_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18879_hap2_hprc_r2_v1.0.1,111122947
+HG00738,1,s3://human-pangenomics/working/HPRC/HG00738/assemblies/release2/annotation/cat/HG00738_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00738_pat_hprc_r2_v1.0.1,107801938
+HG02984,1,s3://human-pangenomics/working/HPRC/HG02984/assemblies/release2/annotation/cat/HG02984_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02984_pat_hprc_r2_v1.0.1,108890723
+NA19391,1,s3://human-pangenomics/working/HPRC/NA19391/assemblies/release2/annotation/cat/NA19391_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA19391_hap1_hprc_r2_v1.0.1,112339093
+HG02148,2,s3://human-pangenomics/working/HPRC/HG02148/assemblies/release2/annotation/cat/HG02148_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02148_mat_hprc_r2_v1.0.1,111204801
+HG02572,2,s3://human-pangenomics/working/HPRC/HG02572/assemblies/release2/annotation/cat/HG02572_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02572_mat_hprc_r2_v1.0.1,111741680
+HG02392,2,s3://human-pangenomics/working/HPRC/HG02392/assemblies/release2/annotation/cat/HG02392_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02392_hap2_hprc_r2_v1.0.1,111757409
+HG02056,2,s3://human-pangenomics/working/HPRC/HG02056/assemblies/release2/annotation/cat/HG02056_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02056_mat_hprc_r2_v1.0.1,112174813
+HG00558,1,s3://human-pangenomics/working/HPRC/HG00558/assemblies/release2/annotation/cat/HG00558_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00558_pat_hprc_r2_v1.0.1,111225110
+NA19159,1,s3://human-pangenomics/working/HPRC/NA19159/assemblies/release2/annotation/cat/NA19159_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA19159_hap1_hprc_r2_v1.0.1,112069842
+HG00146,1,s3://human-pangenomics/working/HPRC/HG00146/assemblies/release2/annotation/cat/HG00146_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00146_hap1_hprc_r2_v1.0.1,111770519
+HG04184,2,s3://human-pangenomics/working/HPRC/HG04184/assemblies/release2/annotation/cat/HG04184_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG04184_mat_hprc_r2_v1.0.1,111548353
+NA19391,2,s3://human-pangenomics/working/HPRC/NA19391/assemblies/release2/annotation/cat/NA19391_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA19391_hap2_hprc_r2_v1.0.1,111837346
+HG03942,2,s3://human-pangenomics/working/HPRC/HG03942/assemblies/release2/annotation/cat/HG03942_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03942_mat_hprc_r2_v1.0.1,110042619
+HG03369,2,s3://human-pangenomics/working/HPRC/HG03369/assemblies/release2/annotation/cat/HG03369_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03369_hap2_hprc_r2_v1.0.1,110994998
+HG03874,1,s3://human-pangenomics/working/HPRC/HG03874/assemblies/release2/annotation/cat/HG03874_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03874_hap1_hprc_r2_v1.0.1,112463617
+HG00423,2,s3://human-pangenomics/working/HPRC/HG00423/assemblies/release2/annotation/cat/HG00423_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00423_mat_hprc_r2_v1.0.1,110024597
+HG01192,2,s3://human-pangenomics/working/HPRC/HG01192/assemblies/release2/annotation/cat/HG01192_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01192_mat_hprc_r2_v1.0.1,111074762
+HG02615,1,s3://human-pangenomics/working/HPRC/HG02615/assemblies/release2/annotation/cat/HG02615_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02615_pat_hprc_r2_v1.0.1,111664888
+HG02647,2,s3://human-pangenomics/working/HPRC/HG02647/assemblies/release2/annotation/cat/HG02647_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02647_mat_hprc_r2_v1.0.1,112531877
+HG01496,1,s3://human-pangenomics/working/HPRC/HG01496/assemblies/release2/annotation/cat/HG01496_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01496_pat_hprc_r2_v1.0.1,112085725
+HG02630,2,s3://human-pangenomics/working/HPRC/HG02630/assemblies/release2/annotation/cat/HG02630_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02630_mat_hprc_r2_v1.0.1,111967905
+HG01530,2,s3://human-pangenomics/working/HPRC/HG01530/assemblies/release2/annotation/cat/HG01530_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01530_hap2_hprc_r2_v1.0.1,111506930
+HG01150,1,s3://human-pangenomics/working/HPRC/HG01150/assemblies/release2/annotation/cat/HG01150_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01150_pat_hprc_r2_v1.0.1,111785976
+NA18960,2,s3://human-pangenomics/working/HPP/NA18960/assemblies/release2/annotation/cat/NA18960_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18960_hap2_hprc_r2_v1.0.1,103890316
+HG00544,2,s3://human-pangenomics/working/HPRC/HG00544/assemblies/release2/annotation/cat/HG00544_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00544_mat_hprc_r2_v1.0.1,111078170
+HG02391,2,s3://human-pangenomics/working/HPRC/HG02391/assemblies/release2/annotation/cat/HG02391_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02391_hap2_hprc_r2_v1.0.1,112133382
+HG02145,1,s3://human-pangenomics/working/HPRC_PLUS/HG02145/assemblies/release2/annotation/cat/HG02145_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02145_pat_hprc_r2_v1.0.1,101285527
+NA18608,1,s3://human-pangenomics/working/HPRC/NA18608/assemblies/release2/annotation/cat/NA18608_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18608_hap1_hprc_r2_v1.0.1,108874093
+HG00126,2,s3://human-pangenomics/working/HPRC/HG00126/assemblies/release2/annotation/cat/HG00126_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00126_hap2_hprc_r2_v1.0.1,111894616
+HG03816,1,s3://human-pangenomics/working/HPRC/HG03816/assemblies/release2/annotation/cat/HG03816_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03816_pat_hprc_r2_v1.0.1,112069298
+NA18508,1,s3://human-pangenomics/working/HPRC/NA18508/assemblies/release2/annotation/cat/NA18508_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18508_hap1_hprc_r2_v1.0.1,111705842
+HG03742,2,s3://human-pangenomics/working/HPRC/HG03742/assemblies/release2/annotation/cat/HG03742_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03742_hap2_hprc_r2_v1.0.1,111604810
+NA19776,1,s3://human-pangenomics/working/HPRC/NA19776/assemblies/release2/annotation/cat/NA19776_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA19776_hap1_hprc_r2_v1.0.1,111125823
+HG00639,1,s3://human-pangenomics/working/HPRC/HG00639/assemblies/release2/annotation/cat/HG00639_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00639_pat_hprc_r2_v1.0.1,111534481
+NA20850,1,s3://human-pangenomics/working/HPRC/NA20850/assemblies/release2/annotation/cat/NA20850_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA20850_hap1_hprc_r2_v1.0.1,107859674
+HG03669,2,s3://human-pangenomics/working/HPRC/HG03669/assemblies/release2/annotation/cat/HG03669_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03669_mat_hprc_r2_v1.0.1,111303046
+NA19043,1,s3://human-pangenomics/working/HPRC/NA19043/assemblies/release2/annotation/cat/NA19043_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA19043_hap1_hprc_r2_v1.0.1,108791696
+HG03927,1,s3://human-pangenomics/working/HPRC/HG03927/assemblies/release2/annotation/cat/HG03927_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03927_pat_hprc_r2_v1.0.1,112563752
+HG02109,1,s3://human-pangenomics/working/HPRC_PLUS/HG02109/assemblies/release2/annotation/cat/HG02109_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02109_pat_hprc_r2_v1.0.1,103888472
+NA19835,2,s3://human-pangenomics/working/HPRC/NA19835/assemblies/release2/annotation/cat/NA19835_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA19835_hap2_hprc_r2_v1.0.1,111038310
+HG02392,1,s3://human-pangenomics/working/HPRC/HG02392/assemblies/release2/annotation/cat/HG02392_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02392_hap1_hprc_r2_v1.0.1,109493374
+HG03834,1,s3://human-pangenomics/working/HPRC/HG03834/assemblies/release2/annotation/cat/HG03834_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03834_pat_hprc_r2_v1.0.1,111097263
+HG00099,2,s3://human-pangenomics/working/HPRC/HG00099/assemblies/release2/annotation/cat/HG00099_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00099_hap2_hprc_r2_v1.0.1,112644607
+NA18943,1,s3://human-pangenomics/working/HPP/NA18943/assemblies/release2/annotation/cat/NA18943_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18943_hap1_hprc_r2_v1.0.1,101062234
+NA19835,1,s3://human-pangenomics/working/HPRC/NA19835/assemblies/release2/annotation/cat/NA19835_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA19835_hap1_hprc_r2_v1.0.1,110670993
+HG04160,2,s3://human-pangenomics/working/HPRC/HG04160/assemblies/release2/annotation/cat/HG04160_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG04160_mat_hprc_r2_v1.0.1,112414038
+HG02129,1,s3://human-pangenomics/working/HPRC/HG02129/assemblies/release2/annotation/cat/HG02129_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02129_pat_hprc_r2_v1.0.1,109781147
+HG04160,1,s3://human-pangenomics/working/HPRC/HG04160/assemblies/release2/annotation/cat/HG04160_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG04160_pat_hprc_r2_v1.0.1,109339701
+HG00099,1,s3://human-pangenomics/working/HPRC/HG00099/assemblies/release2/annotation/cat/HG00099_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00099_hap1_hprc_r2_v1.0.1,112383343
+HG03130,2,s3://human-pangenomics/working/HPRC/HG03130/assemblies/release2/annotation/cat/HG03130_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03130_hap2_hprc_r2_v1.0.1,112549652
+HG02922,1,s3://human-pangenomics/working/HPRC/HG02922/assemblies/release2/annotation/cat/HG02922_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02922_hap1_hprc_r2_v1.0.1,113354135
+HG02514,1,s3://human-pangenomics/working/HPRC/HG02514/assemblies/release2/annotation/cat/HG02514_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02514_pat_hprc_r2_v1.0.1,108548944
+HG01993,2,s3://human-pangenomics/working/HPRC/HG01993/assemblies/release2/annotation/cat/HG01993_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01993_mat_hprc_r2_v1.0.1,111766139
+HG02976,1,s3://human-pangenomics/working/HPRC/HG02976/assemblies/release2/annotation/cat/HG02976_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02976_hap1_hprc_r2_v1.0.1,116148296
+HG01243,2,s3://human-pangenomics/working/HPRC_PLUS/HG01243/assemblies/release2/annotation/cat/HG01243_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01243_mat_hprc_r2_v1.0.1,103903907
+HG03540,2,s3://human-pangenomics/working/HPRC/HG03540/assemblies/release2/annotation/cat/HG03540_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03540_mat_hprc_r2_v1.0.1,112915500
+HG01071,2,s3://human-pangenomics/working/HPRC/HG01071/assemblies/release2/annotation/cat/HG01071_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01071_mat_hprc_r2_v1.0.1,110475283
+HG03516,2,s3://human-pangenomics/working/HPRC/HG03516/assemblies/release2/annotation/cat/HG03516_mat_hprc_r2_v1.1.0_cat_v1.3.gff3.gz,CAT Genes,2,HG03516_mat_hprc_r2_v1.1.0,112701660
+HG02027,2,s3://human-pangenomics/working/HPRC/HG02027/assemblies/release2/annotation/cat/HG02027_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02027_mat_hprc_r2_v1.0.1,110037897
+HG03784,1,s3://human-pangenomics/working/HPRC/HG03784/assemblies/release2/annotation/cat/HG03784_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03784_hap1_hprc_r2_v1.0.1,111104322
+HG00733,1,s3://human-pangenomics/working/HPRC_PLUS/HG00733/assemblies/release2/annotation/cat/HG00733_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00733_pat_hprc_r2_v1.0.1,103914945
+HG02602,2,s3://human-pangenomics/working/HPRC/HG02602/assemblies/release2/annotation/cat/HG02602_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02602_mat_hprc_r2_v1.0.1,112554141
+NA19240,2,s3://human-pangenomics/working/HPRC_PLUS/NA19240/assemblies/release2/annotation/cat/NA19240_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA19240_mat_hprc_r2_v1.0.1,104164399
+HG03209,2,s3://human-pangenomics/working/HPRC/HG03209/assemblies/release2/annotation/cat/HG03209_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03209_hap2_hprc_r2_v1.0.1,112256093
+HG01433,1,s3://human-pangenomics/working/HPRC/HG01433/assemblies/release2/annotation/cat/HG01433_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01433_pat_hprc_r2_v1.0.1,108777165
+HG00733,2,s3://human-pangenomics/working/HPRC_PLUS/HG00733/assemblies/release2/annotation/cat/HG00733_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00733_mat_hprc_r2_v1.0.1,104281063
+HG03470,2,s3://human-pangenomics/working/HPRC/HG03470/assemblies/release2/annotation/cat/HG03470_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03470_hap2_hprc_r2_v1.0.1,112183008
+HG00140,2,s3://human-pangenomics/working/HPRC/HG00140/assemblies/release2/annotation/cat/HG00140_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00140_hap2_hprc_r2_v1.0.1,112325367
+NA20806,1,s3://human-pangenomics/working/HPRC/NA20806/assemblies/release2/annotation/cat/NA20806_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA20806_hap1_hprc_r2_v1.0.1,107612933
+NA18522,1,s3://human-pangenomics/working/HPRC/NA18522/assemblies/release2/annotation/cat/NA18522_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18522_hap1_hprc_r2_v1.0.1,110553725
+HG03831,2,s3://human-pangenomics/working/HPRC/HG03831/assemblies/release2/annotation/cat/HG03831_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03831_mat_hprc_r2_v1.0.1,111870007
+HG00609,1,s3://human-pangenomics/working/HPRC/HG00609/assemblies/release2/annotation/cat/HG00609_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00609_pat_hprc_r2_v1.0.1,108950941
+HG01099,1,s3://human-pangenomics/working/HPRC/HG01099/assemblies/release2/annotation/cat/HG01099_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01099_pat_hprc_r2_v1.0.1,107802453
+HG02965,2,s3://human-pangenomics/working/HPRC/HG02965/assemblies/release2/annotation/cat/HG02965_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02965_hap2_hprc_r2_v1.0.1,112789810
+HG03239,1,s3://human-pangenomics/working/HPRC/HG03239/assemblies/release2/annotation/cat/HG03239_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03239_pat_hprc_r2_v1.0.1,111417576
+NA18974,2,s3://human-pangenomics/working/HPRC/NA18974/assemblies/release2/annotation/cat/NA18974_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18974_hap2_hprc_r2_v1.0.1,111454734
+HG03583,2,s3://human-pangenomics/working/HPRC/HG03583/assemblies/release2/annotation/cat/HG03583_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03583_hap2_hprc_r2_v1.0.1,111326138
+HG00735,2,s3://human-pangenomics/working/HPRC/HG00735/assemblies/release2/annotation/cat/HG00735_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00735_mat_hprc_r2_v1.0.1,110357169
+HG02559,2,s3://human-pangenomics/working/HPRC/HG02559/assemblies/release2/annotation/cat/HG02559_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02559_mat_hprc_r2_v1.0.1,104137454
+HG03874,2,s3://human-pangenomics/working/HPRC/HG03874/assemblies/release2/annotation/cat/HG03874_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03874_hap2_hprc_r2_v1.0.1,112223441
+HG06807,2,s3://human-pangenomics/working/HPRC/HG06807/assemblies/release2/annotation/cat/HG06807_mat_v1_cat_v1.3.gff3.gz,CAT Genes,2,HG06807_mat_v1,104265541
+HG03098,1,s3://human-pangenomics/working/HPRC_PLUS/HG03098/assemblies/release2/annotation/cat/HG03098_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03098_pat_hprc_r2_v1.0.1,101024449
+NA20799,2,s3://human-pangenomics/working/HPRC/NA20799/assemblies/release2/annotation/cat/NA20799_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA20799_hap2_hprc_r2_v1.0.1,111598176
+HG03579,1,s3://human-pangenomics/working/HPRC/HG03579/assemblies/release2/annotation/cat/HG03579_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03579_pat_hprc_r2_v1.0.1,107547995
+NA18620,2,s3://human-pangenomics/working/HPRC/NA18620/assemblies/release2/annotation/cat/NA18620_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18620_hap2_hprc_r2_v1.0.1,112270917
+NA18948,1,s3://human-pangenomics/working/HPP/NA18948/assemblies/release2/annotation/cat/NA18948_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18948_hap1_hprc_r2_v1.0.1,101019430
+NA20752,2,s3://human-pangenomics/working/HPRC/NA20752/assemblies/release2/annotation/cat/NA20752_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA20752_hap2_hprc_r2_v1.0.1,111843874
+HG04184,1,s3://human-pangenomics/working/HPRC/HG04184/assemblies/release2/annotation/cat/HG04184_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG04184_pat_hprc_r2_v1.0.1,111554165
+NA18945,1,s3://human-pangenomics/working/HPP/NA18945/assemblies/release2/annotation/cat/NA18945_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18945_hap1_hprc_r2_v1.0.1,99611882
+HG03704,1,s3://human-pangenomics/working/HPRC/HG03704/assemblies/release2/annotation/cat/HG03704_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03704_pat_hprc_r2_v1.0.1,111399475
+HG02451,2,s3://human-pangenomics/working/HPRC/HG02451/assemblies/release2/annotation/cat/HG02451_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02451_mat_hprc_r2_v1.0.1,110166655
+HG02886,1,s3://human-pangenomics/working/HPRC/HG02886/assemblies/release2/annotation/cat/HG02886_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02886_pat_hprc_r2_v1.0.1,112333309
+HG00290,2,s3://human-pangenomics/working/HPRC/HG00290/assemblies/release2/annotation/cat/HG00290_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00290_hap2_hprc_r2_v1.0.1,111569374
+NA18982,2,s3://human-pangenomics/working/HPP/NA18982/assemblies/release2/annotation/cat/NA18982_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18982_hap2_hprc_r2_v1.0.1,103803539
+HG02738,2,s3://human-pangenomics/working/HPRC/HG02738/assemblies/release2/annotation/cat/HG02738_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02738_mat_hprc_r2_v1.0.1,111411520
+HG02083,2,s3://human-pangenomics/working/HPRC/HG02083/assemblies/release2/annotation/cat/HG02083_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02083_mat_hprc_r2_v1.0.1,111227824
+HG00408,1,s3://human-pangenomics/working/HPRC/HG00408/assemblies/release2/annotation/cat/HG00408_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00408_pat_hprc_r2_v1.0.1,112484879
+HG03927,2,s3://human-pangenomics/working/HPRC/HG03927/assemblies/release2/annotation/cat/HG03927_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03927_mat_hprc_r2_v1.0.1,112627150
+HG01960,1,s3://human-pangenomics/working/HPRC/HG01960/assemblies/release2/annotation/cat/HG01960_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01960_pat_hprc_r2_v1.0.1,111512143
+HG00344,2,s3://human-pangenomics/working/HPRC/HG00344/assemblies/release2/annotation/cat/HG00344_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00344_hap2_hprc_r2_v1.0.1,110391421
+HG02818,1,s3://human-pangenomics/working/HPRC_PLUS/HG02818/assemblies/release2/annotation/cat/HG02818_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02818_pat_hprc_r2_v1.0.1,104089750
+HG02698,1,s3://human-pangenomics/working/HPRC/HG02698/assemblies/release2/annotation/cat/HG02698_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02698_pat_hprc_r2_v1.0.1,108606868
+HG02015,1,s3://human-pangenomics/working/HPRC/HG02015/assemblies/release2/annotation/cat/HG02015_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02015_pat_hprc_r2_v1.0.1,108630889
+HG03041,2,s3://human-pangenomics/working/HPRC/HG03041/assemblies/release2/annotation/cat/HG03041_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03041_mat_hprc_r2_v1.0.1,111933513
+HG04199,1,s3://human-pangenomics/working/HPRC/HG04199/assemblies/release2/annotation/cat/HG04199_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG04199_pat_hprc_r2_v1.0.1,108697420
+HG01167,2,s3://human-pangenomics/working/HPRC/HG01167/assemblies/release2/annotation/cat/HG01167_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01167_hap2_hprc_r2_v1.0.1,110882769
+HG03804,1,s3://human-pangenomics/working/HPRC/HG03804/assemblies/release2/annotation/cat/HG03804_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03804_pat_hprc_r2_v1.0.1,112216676
+HG01123,1,s3://human-pangenomics/working/HPRC/HG01123/assemblies/release2/annotation/cat/HG01123_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01123_pat_hprc_r2_v1.0.1,103999805
+NA20905,1,s3://human-pangenomics/working/HPRC/NA20905/assemblies/release2/annotation/cat/NA20905_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA20905_hap1_hprc_r2_v1.0.1,109068047
+HG03831,1,s3://human-pangenomics/working/HPRC/HG03831/assemblies/release2/annotation/cat/HG03831_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03831_pat_hprc_r2_v1.0.1,112206356
+HG01433,2,s3://human-pangenomics/working/HPRC/HG01433/assemblies/release2/annotation/cat/HG01433_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01433_mat_hprc_r2_v1.0.1,111711355
+NA18944,1,s3://human-pangenomics/working/HPP/NA18944/assemblies/release2/annotation/cat/NA18944_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18944_hap1_hprc_r2_v1.0.1,101091440
+NA19682,2,s3://human-pangenomics/working/HPRC/NA19682/assemblies/release2/annotation/cat/NA19682_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA19682_hap2_hprc_r2_v1.0.1,111351060
+HG03486,2,s3://human-pangenomics/working/HPRC_PLUS/HG03486/assemblies/release2/annotation/cat/HG03486_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03486_mat_hprc_r2_v1.0.1,104355126
+HG02257,1,s3://human-pangenomics/working/HPRC/HG02257/assemblies/release2/annotation/cat/HG02257_pat_hprc_r2_v1.1.0_cat_v1.3.gff3.gz,CAT Genes,2,HG02257_pat_hprc_r2_v1.1.0,113792323
+HG02280,2,s3://human-pangenomics/working/HPRC/HG02280/assemblies/release2/annotation/cat/HG02280_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02280_mat_hprc_r2_v1.0.1,112177024
+NA18505,2,s3://human-pangenomics/working/HPRC/NA18505/assemblies/release2/annotation/cat/NA18505_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18505_hap2_hprc_r2_v1.0.1,114929007
+NA19468,1,s3://human-pangenomics/working/HPRC/NA19468/assemblies/release2/annotation/cat/NA19468_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA19468_hap1_hprc_r2_v1.0.1,111588192
+HG02668,2,s3://human-pangenomics/working/HPRC/HG02668/assemblies/release2/annotation/cat/HG02668_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02668_mat_hprc_r2_v1.0.1,111436969
+HG02280,1,s3://human-pangenomics/working/HPRC/HG02280/assemblies/release2/annotation/cat/HG02280_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02280_pat_hprc_r2_v1.0.1,112203656
+HG02809,2,s3://human-pangenomics/working/HPRC/HG02809/assemblies/release2/annotation/cat/HG02809_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02809_mat_hprc_r2_v1.0.1,112075743
+HG01252,2,s3://human-pangenomics/working/HPRC/HG01252/assemblies/release2/annotation/cat/HG01252_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01252_mat_hprc_r2_v1.0.1,111681251
+NA20752,1,s3://human-pangenomics/working/HPRC/NA20752/assemblies/release2/annotation/cat/NA20752_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA20752_hap1_hprc_r2_v1.0.1,108777313
+HG01952,1,s3://human-pangenomics/working/HPRC/HG01952/assemblies/release2/annotation/cat/HG01952_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01952_pat_hprc_r2_v1.0.1,107800663
+HG02668,1,s3://human-pangenomics/working/HPRC/HG02668/assemblies/release2/annotation/cat/HG02668_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02668_pat_hprc_r2_v1.0.1,108376799
+HG02148,1,s3://human-pangenomics/working/HPRC/HG02148/assemblies/release2/annotation/cat/HG02148_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02148_pat_hprc_r2_v1.0.1,111296268
+HG01361,1,s3://human-pangenomics/working/HPRC/HG01361/assemblies/release2/annotation/cat/HG01361_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01361_pat_hprc_r2_v1.0.1,112417104
+HG02984,2,s3://human-pangenomics/working/HPRC/HG02984/assemblies/release2/annotation/cat/HG02984_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02984_mat_hprc_r2_v1.0.1,111791666
+NA18508,2,s3://human-pangenomics/working/HPRC/NA18508/assemblies/release2/annotation/cat/NA18508_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18508_hap2_hprc_r2_v1.0.1,112664603
+NA18944,2,s3://human-pangenomics/working/HPP/NA18944/assemblies/release2/annotation/cat/NA18944_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18944_hap2_hprc_r2_v1.0.1,103918195
+HG01106,1,s3://human-pangenomics/working/HPRC/HG01106/assemblies/release2/annotation/cat/HG01106_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01106_pat_hprc_r2_v1.0.1,108095420
+HG04228,2,s3://human-pangenomics/working/HPRC/HG04228/assemblies/release2/annotation/cat/HG04228_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG04228_mat_hprc_r2_v1.0.1,111489720
+HG03942,1,s3://human-pangenomics/working/HPRC/HG03942/assemblies/release2/annotation/cat/HG03942_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03942_pat_hprc_r2_v1.0.1,107167383
+HG04204,2,s3://human-pangenomics/working/HPRC/HG04204/assemblies/release2/annotation/cat/HG04204_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG04204_mat_hprc_r2_v1.0.1,111456147
+HG04228,1,s3://human-pangenomics/working/HPRC/HG04228/assemblies/release2/annotation/cat/HG04228_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG04228_pat_hprc_r2_v1.0.1,108494852
+HG02615,2,s3://human-pangenomics/working/HPRC/HG02615/assemblies/release2/annotation/cat/HG02615_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02615_mat_hprc_r2_v1.0.1,111583591
+HG00253,2,s3://human-pangenomics/working/HPRC/HG00253/assemblies/release2/annotation/cat/HG00253_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00253_hap2_hprc_r2_v1.0.1,110518164
+NA18505,1,s3://human-pangenomics/working/HPRC/NA18505/assemblies/release2/annotation/cat/NA18505_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18505_hap1_hprc_r2_v1.0.1,114448514
+HG03804,2,s3://human-pangenomics/working/HPRC/HG03804/assemblies/release2/annotation/cat/HG03804_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03804_mat_hprc_r2_v1.0.1,112171548
+HG01975,2,s3://human-pangenomics/working/HPRC/HG01975/assemblies/release2/annotation/cat/HG01975_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01975_mat_hprc_r2_v1.0.1,112229027
+HG03710,1,s3://human-pangenomics/working/HPRC/HG03710/assemblies/release2/annotation/cat/HG03710_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03710_pat_hprc_r2_v1.0.1,109177035
+HG00235,2,s3://human-pangenomics/working/HPRC/HG00235/assemblies/release2/annotation/cat/HG00235_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00235_hap2_hprc_r2_v1.0.1,110858765
+HG02258,2,s3://human-pangenomics/working/HPRC/HG02258/assemblies/release2/annotation/cat/HG02258_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02258_mat_hprc_r2_v1.0.1,112411076
+HG02583,1,s3://human-pangenomics/working/HPRC/HG02583/assemblies/release2/annotation/cat/HG02583_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02583_hap1_hprc_r2_v1.0.1,111333548
+HG01940,2,s3://human-pangenomics/working/HPRC/HG01940/assemblies/release2/annotation/cat/HG01940_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01940_mat_hprc_r2_v1.0.1,111815971
+HG00128,2,s3://human-pangenomics/working/HPRC/HG00128/assemblies/release2/annotation/cat/HG00128_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00128_hap2_hprc_r2_v1.0.1,110826371
+NA18971,1,s3://human-pangenomics/working/HPRC/NA18971/assemblies/release2/annotation/cat/NA18971_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18971_hap1_hprc_r2_v1.0.1,107882733
+HG01969,1,s3://human-pangenomics/working/HPRC/HG01969/assemblies/release2/annotation/cat/HG01969_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01969_pat_hprc_r2_v1.0.1,110811361
+NA19443,2,s3://human-pangenomics/working/HPRC/NA19443/assemblies/release2/annotation/cat/NA19443_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA19443_hap2_hprc_r2_v1.0.1,111282384
+HG01943,2,s3://human-pangenomics/working/HPRC/HG01943/assemblies/release2/annotation/cat/HG01943_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01943_mat_hprc_r2_v1.0.1,111941501
+NA18747,1,s3://human-pangenomics/working/HPRC/NA18747/assemblies/release2/annotation/cat/NA18747_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18747_hap1_hprc_r2_v1.0.1,106994007
+NA21309,2,s3://human-pangenomics/working/HPRC_PLUS/NA21309/assemblies/release2/annotation/cat/NA21309_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA21309_mat_hprc_r2_v1.0.1,104132495
+NA21106,1,s3://human-pangenomics/working/HPRC/NA21106/assemblies/release2/annotation/cat/NA21106_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA21106_hap1_hprc_r2_v1.0.1,113409741
+NA18952,2,s3://human-pangenomics/working/HPRC/NA18952/assemblies/release2/annotation/cat/NA18952_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18952_hap2_hprc_r2_v1.0.1,111515457
+HG03654,2,s3://human-pangenomics/working/HPRC/HG03654/assemblies/release2/annotation/cat/HG03654_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG03654_mat_hprc_r2_v1.0.1,112642665
+NA18967,1,s3://human-pangenomics/working/HPP/NA18967/assemblies/release2/annotation/cat/NA18967_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18967_hap1_hprc_r2_v1.0.1,108110620
+HG00235,1,s3://human-pangenomics/working/HPRC/HG00235/assemblies/release2/annotation/cat/HG00235_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00235_hap1_hprc_r2_v1.0.1,110545161
+HG01358,2,s3://human-pangenomics/working/HPRC/HG01358/assemblies/release2/annotation/cat/HG01358_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01358_mat_hprc_r2_v1.0.1,112072866
+NA20905,2,s3://human-pangenomics/working/HPRC/NA20905/assemblies/release2/annotation/cat/NA20905_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA20905_hap2_hprc_r2_v1.0.1,112247802
+HG02451,1,s3://human-pangenomics/working/HPRC/HG02451/assemblies/release2/annotation/cat/HG02451_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02451_pat_hprc_r2_v1.0.1,110231844
+NA18983,1,s3://human-pangenomics/working/HPRC/NA18983/assemblies/release2/annotation/cat/NA18983_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18983_hap1_hprc_r2_v1.0.1,107604616
+HG01099,2,s3://human-pangenomics/working/HPRC/HG01099/assemblies/release2/annotation/cat/HG01099_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01099_mat_hprc_r2_v1.0.1,110390731
+HG01934,2,s3://human-pangenomics/working/HPRC/HG01934/assemblies/release2/annotation/cat/HG01934_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01934_mat_hprc_r2_v1.0.1,111856184
+NA19159,2,s3://human-pangenomics/working/HPRC/NA19159/assemblies/release2/annotation/cat/NA19159_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA19159_hap2_hprc_r2_v1.0.1,111934494
+HG00097,1,s3://human-pangenomics/working/HPRC/HG00097/assemblies/release2/annotation/cat/HG00097_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00097_hap1_hprc_r2_v1.0.1,110885584
+HG005,1,s3://human-pangenomics/working/HPRC_PLUS/HG005/assemblies/release2/annotation/cat/HG005_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG005_pat_hprc_r2_v1.0.1,100694727
+NA20805,2,s3://human-pangenomics/working/HPRC/NA20805/assemblies/release2/annotation/cat/NA20805_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA20805_hap2_hprc_r2_v1.0.1,111286654
+HG02818,2,s3://human-pangenomics/working/HPRC_PLUS/HG02818/assemblies/release2/annotation/cat/HG02818_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02818_mat_hprc_r2_v1.0.1,104125156
+HG00741,1,s3://human-pangenomics/working/HPRC/HG00741/assemblies/release2/annotation/cat/HG00741_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00741_pat_hprc_r2_v1.0.1,110057191
+HG02965,1,s3://human-pangenomics/working/HPRC/HG02965/assemblies/release2/annotation/cat/HG02965_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02965_hap1_hprc_r2_v1.0.1,109467468
+HG02273,1,s3://human-pangenomics/working/HPRC/HG02273/assemblies/release2/annotation/cat/HG02273_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02273_hap1_hprc_r2_v1.0.1,113560715
+HG02132,2,s3://human-pangenomics/working/HPRC/HG02132/assemblies/release2/annotation/cat/HG02132_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02132_mat_hprc_r2_v1.0.1,110556000
+HG01786,1,s3://human-pangenomics/working/HPRC/HG01786/assemblies/release2/annotation/cat/HG01786_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG01786_hap1_hprc_r2_v1.0.1,111464937
+HG02602,1,s3://human-pangenomics/working/HPRC/HG02602/assemblies/release2/annotation/cat/HG02602_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG02602_pat_hprc_r2_v1.0.1,109330021
+HG00146,2,s3://human-pangenomics/working/HPRC/HG00146/assemblies/release2/annotation/cat/HG00146_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,HG00146_hap2_hprc_r2_v1.0.1,112158535
+NA18570,1,s3://human-pangenomics/working/HPRC/NA18570/assemblies/release2/annotation/cat/NA18570_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz,CAT Genes,2,NA18570_hap1_hprc_r2_v1.0.1,111956692
 HG00408,1,s3://human-pangenomics/working/HPRC/HG00408/assemblies/release2/annotation/censat/HG00408_pat_hprc_r2_v1.cenSat.bed,CenSat,2,HG00408_pat_hprc_r2_v1.0.1,245427
 HG00408,2,s3://human-pangenomics/working/HPRC/HG00408/assemblies/release2/annotation/censat/HG00408_mat_hprc_r2_v1.cenSat.bed,CenSat,2,HG00408_mat_hprc_r2_v1.0.1,248081
 HG00597,1,s3://human-pangenomics/working/HPRC/HG00597/assemblies/release2/annotation/censat/HG00597_pat_hprc_r2_v1.cenSat.bed,CenSat,2,HG00597_pat_hprc_r2_v1.0.1,248901

--- a/catalog/output/alignments.json
+++ b/catalog/output/alignments.json
@@ -671,7 +671,7 @@
   },
   {
     "alignment": "HPRC-v1.0-chm13-pggb",
-    "fileSize": 0,
+    "fileSize": 6581655264,
     "filename": "hprc-v1.0-pggb.chm13.1-22+X.vcf.gz",
     "filetype": "vcf",
     "loc": "s3://human-pangenomics/pangenomes/freeze/freeze1/pggb/vcfs/hprc-v1.0-pggb.chm13.1-22+X.vcf.gz",
@@ -681,7 +681,7 @@
   },
   {
     "alignment": "HPRC-v1.0-chm13-pggb",
-    "fileSize": 0,
+    "fileSize": 2095029,
     "filename": "hprc-v1.0-pggb.chm13.1-22+X.vcf.gz.tbi",
     "filetype": "tbi",
     "loc": "s3://human-pangenomics/pangenomes/freeze/freeze1/pggb/vcfs/hprc-v1.0-pggb.chm13.1-22+X.vcf.gz.tbi",
@@ -711,7 +711,7 @@
   },
   {
     "alignment": "HPRC-v1.0-grch38-pggb",
-    "fileSize": 0,
+    "fileSize": 5699475467,
     "filename": "hprc-v1.0-pggb.grch38.1-22+X.vcf.gz",
     "filetype": "vcf",
     "loc": "s3://human-pangenomics/pangenomes/freeze/freeze1/pggb/vcfs/hprc-v1.0-pggb.grch38.1-22+X.vcf.gz",
@@ -721,7 +721,7 @@
   },
   {
     "alignment": "HPRC-v1.0-grch38-pggb",
-    "fileSize": 0,
+    "fileSize": 2023126,
     "filename": "hprc-v1.0-pggb.grch38.1-22+X.vcf.gz.tbi",
     "filetype": "tbi",
     "loc": "s3://human-pangenomics/pangenomes/freeze/freeze1/pggb/vcfs/hprc-v1.0-pggb.grch38.1-22+X.vcf.gz.tbi",

--- a/catalog/output/annotations.json
+++ b/catalog/output/annotations.json
@@ -37,9 +37,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00097/assemblies/release2/annotation/cat/HG00097_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63194321,
-    "filename": "HG00097_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00097/assemblies/release2/annotation/cat/HG00097_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110616252,
+    "filename": "HG00097_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00097"
@@ -190,9 +190,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00097/assemblies/release2/annotation/cat/HG00097_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63338462,
-    "filename": "HG00097_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00097/assemblies/release2/annotation/cat/HG00097_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110885584,
+    "filename": "HG00097_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00097"
@@ -343,9 +343,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00099/assemblies/release2/annotation/cat/HG00099_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63678632,
-    "filename": "HG00099_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00099/assemblies/release2/annotation/cat/HG00099_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112644607,
+    "filename": "HG00099_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00099"
@@ -496,9 +496,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00099/assemblies/release2/annotation/cat/HG00099_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63503727,
-    "filename": "HG00099_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00099/assemblies/release2/annotation/cat/HG00099_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112383343,
+    "filename": "HG00099_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00099"
@@ -649,9 +649,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00126/assemblies/release2/annotation/cat/HG00126_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63362497,
-    "filename": "HG00126_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00126/assemblies/release2/annotation/cat/HG00126_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111894616,
+    "filename": "HG00126_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00126"
@@ -802,9 +802,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00126/assemblies/release2/annotation/cat/HG00126_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61750437,
-    "filename": "HG00126_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00126/assemblies/release2/annotation/cat/HG00126_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108823951,
+    "filename": "HG00126_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00126"
@@ -955,9 +955,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00128/assemblies/release2/annotation/cat/HG00128_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63216826,
-    "filename": "HG00128_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00128/assemblies/release2/annotation/cat/HG00128_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110826371,
+    "filename": "HG00128_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00128"
@@ -1108,9 +1108,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00128/assemblies/release2/annotation/cat/HG00128_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63234923,
-    "filename": "HG00128_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00128/assemblies/release2/annotation/cat/HG00128_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111006252,
+    "filename": "HG00128_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00128"
@@ -1261,9 +1261,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00133/assemblies/release2/annotation/cat/HG00133_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63394214,
-    "filename": "HG00133_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00133/assemblies/release2/annotation/cat/HG00133_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111549817,
+    "filename": "HG00133_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00133"
@@ -1414,9 +1414,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00133/assemblies/release2/annotation/cat/HG00133_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63216022,
-    "filename": "HG00133_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00133/assemblies/release2/annotation/cat/HG00133_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111527661,
+    "filename": "HG00133_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00133"
@@ -1567,9 +1567,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00140/assemblies/release2/annotation/cat/HG00140_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63802665,
-    "filename": "HG00140_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00140/assemblies/release2/annotation/cat/HG00140_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112325367,
+    "filename": "HG00140_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00140"
@@ -1720,9 +1720,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00140/assemblies/release2/annotation/cat/HG00140_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61666996,
-    "filename": "HG00140_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00140/assemblies/release2/annotation/cat/HG00140_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108510327,
+    "filename": "HG00140_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00140"
@@ -1873,9 +1873,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00146/assemblies/release2/annotation/cat/HG00146_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63881048,
-    "filename": "HG00146_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00146/assemblies/release2/annotation/cat/HG00146_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112158535,
+    "filename": "HG00146_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00146"
@@ -2026,9 +2026,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00146/assemblies/release2/annotation/cat/HG00146_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63473413,
-    "filename": "HG00146_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00146/assemblies/release2/annotation/cat/HG00146_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111770519,
+    "filename": "HG00146_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00146"
@@ -2180,7 +2180,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG002/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG002-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 53066037,
     "filename": "AS-HOR+SF-vs-HG002-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -2279,7 +2279,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG002/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG002-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 52893924,
     "filename": "AS-HOR+SF-vs-HG002-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -2350,9 +2350,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00232/assemblies/release2/annotation/cat/HG00232_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63477152,
-    "filename": "HG00232_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00232/assemblies/release2/annotation/cat/HG00232_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111689854,
+    "filename": "HG00232_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00232"
@@ -2503,9 +2503,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00232/assemblies/release2/annotation/cat/HG00232_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63488149,
-    "filename": "HG00232_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00232/assemblies/release2/annotation/cat/HG00232_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111745408,
+    "filename": "HG00232_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00232"
@@ -2656,9 +2656,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00235/assemblies/release2/annotation/cat/HG00235_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63459446,
-    "filename": "HG00235_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00235/assemblies/release2/annotation/cat/HG00235_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110858765,
+    "filename": "HG00235_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00235"
@@ -2809,9 +2809,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00235/assemblies/release2/annotation/cat/HG00235_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63429083,
-    "filename": "HG00235_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00235/assemblies/release2/annotation/cat/HG00235_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110545161,
+    "filename": "HG00235_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00235"
@@ -2962,9 +2962,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00253/assemblies/release2/annotation/cat/HG00253_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63452615,
-    "filename": "HG00253_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00253/assemblies/release2/annotation/cat/HG00253_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110518164,
+    "filename": "HG00253_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00253"
@@ -3115,9 +3115,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00253/assemblies/release2/annotation/cat/HG00253_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63207930,
-    "filename": "HG00253_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00253/assemblies/release2/annotation/cat/HG00253_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110402589,
+    "filename": "HG00253_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00253"
@@ -3268,9 +3268,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00272/assemblies/release2/annotation/cat/HG00272_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63362113,
-    "filename": "HG00272_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00272/assemblies/release2/annotation/cat/HG00272_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111021802,
+    "filename": "HG00272_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00272"
@@ -3403,9 +3403,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00272/assemblies/release2/annotation/cat/HG00272_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63286590,
-    "filename": "HG00272_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00272/assemblies/release2/annotation/cat/HG00272_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110846347,
+    "filename": "HG00272_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00272"
@@ -3538,9 +3538,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00280/assemblies/release2/annotation/cat/HG00280_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63562400,
-    "filename": "HG00280_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00280/assemblies/release2/annotation/cat/HG00280_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112542396,
+    "filename": "HG00280_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00280"
@@ -3691,9 +3691,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00280/assemblies/release2/annotation/cat/HG00280_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61942403,
-    "filename": "HG00280_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00280/assemblies/release2/annotation/cat/HG00280_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 109598074,
+    "filename": "HG00280_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00280"
@@ -3844,9 +3844,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00290/assemblies/release2/annotation/cat/HG00290_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63487259,
-    "filename": "HG00290_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00290/assemblies/release2/annotation/cat/HG00290_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111569374,
+    "filename": "HG00290_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00290"
@@ -3997,9 +3997,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00290/assemblies/release2/annotation/cat/HG00290_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61806959,
-    "filename": "HG00290_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00290/assemblies/release2/annotation/cat/HG00290_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108387748,
+    "filename": "HG00290_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00290"
@@ -4150,9 +4150,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00320/assemblies/release2/annotation/cat/HG00320_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63269454,
-    "filename": "HG00320_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00320/assemblies/release2/annotation/cat/HG00320_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110784669,
+    "filename": "HG00320_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00320"
@@ -4303,9 +4303,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00320/assemblies/release2/annotation/cat/HG00320_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63366071,
-    "filename": "HG00320_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00320/assemblies/release2/annotation/cat/HG00320_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111004800,
+    "filename": "HG00320_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00320"
@@ -4456,9 +4456,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00321/assemblies/release2/annotation/cat/HG00321_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63502215,
-    "filename": "HG00321_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00321/assemblies/release2/annotation/cat/HG00321_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 104003218,
+    "filename": "HG00321_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00321"
@@ -4609,9 +4609,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00321/assemblies/release2/annotation/cat/HG00321_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61654608,
-    "filename": "HG00321_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00321/assemblies/release2/annotation/cat/HG00321_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 100890678,
+    "filename": "HG00321_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00321"
@@ -4762,9 +4762,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00323/assemblies/release2/annotation/cat/HG00323_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63410371,
-    "filename": "HG00323_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00323/assemblies/release2/annotation/cat/HG00323_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111085666,
+    "filename": "HG00323_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00323"
@@ -4915,9 +4915,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00323/assemblies/release2/annotation/cat/HG00323_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63552805,
-    "filename": "HG00323_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00323/assemblies/release2/annotation/cat/HG00323_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111370015,
+    "filename": "HG00323_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00323"
@@ -5068,9 +5068,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00329/assemblies/release2/annotation/cat/HG00329_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63452156,
-    "filename": "HG00329_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00329/assemblies/release2/annotation/cat/HG00329_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110850488,
+    "filename": "HG00329_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00329"
@@ -5221,9 +5221,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00329/assemblies/release2/annotation/cat/HG00329_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61534761,
-    "filename": "HG00329_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00329/assemblies/release2/annotation/cat/HG00329_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 107532335,
+    "filename": "HG00329_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00329"
@@ -5374,9 +5374,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00344/assemblies/release2/annotation/cat/HG00344_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63214204,
-    "filename": "HG00344_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00344/assemblies/release2/annotation/cat/HG00344_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110391421,
+    "filename": "HG00344_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00344"
@@ -5527,9 +5527,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00344/assemblies/release2/annotation/cat/HG00344_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63352492,
-    "filename": "HG00344_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00344/assemblies/release2/annotation/cat/HG00344_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110891532,
+    "filename": "HG00344_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00344"
@@ -5680,9 +5680,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00350/assemblies/release2/annotation/cat/HG00350_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63309610,
-    "filename": "HG00350_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00350/assemblies/release2/annotation/cat/HG00350_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111346040,
+    "filename": "HG00350_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00350"
@@ -5833,9 +5833,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00350/assemblies/release2/annotation/cat/HG00350_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63122478,
-    "filename": "HG00350_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00350/assemblies/release2/annotation/cat/HG00350_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110831719,
+    "filename": "HG00350_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00350"
@@ -5986,9 +5986,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00408/assemblies/release2/annotation/cat/HG00408_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63488237,
-    "filename": "HG00408_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00408/assemblies/release2/annotation/cat/HG00408_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112675562,
+    "filename": "HG00408_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00408"
@@ -6139,9 +6139,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00408/assemblies/release2/annotation/cat/HG00408_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63531417,
-    "filename": "HG00408_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00408/assemblies/release2/annotation/cat/HG00408_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112484879,
+    "filename": "HG00408_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00408"
@@ -6292,9 +6292,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00423/assemblies/release2/annotation/cat/HG00423_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 62941730,
-    "filename": "HG00423_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00423/assemblies/release2/annotation/cat/HG00423_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110024597,
+    "filename": "HG00423_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00423"
@@ -6445,9 +6445,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00423/assemblies/release2/annotation/cat/HG00423_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63097834,
-    "filename": "HG00423_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00423/assemblies/release2/annotation/cat/HG00423_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110408896,
+    "filename": "HG00423_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00423"
@@ -6599,7 +6599,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG00438/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00438-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 52488458,
     "filename": "AS-HOR+SF-vs-HG00438-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -6607,9 +6607,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00438/assemblies/release2/annotation/cat/HG00438_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63387207,
-    "filename": "HG00438_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00438/assemblies/release2/annotation/cat/HG00438_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111462142,
+    "filename": "HG00438_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00438"
@@ -6851,7 +6851,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG00438/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00438-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 45400685,
     "filename": "AS-HOR+SF-vs-HG00438-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -6859,9 +6859,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00438/assemblies/release2/annotation/cat/HG00438_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63429945,
-    "filename": "HG00438_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00438/assemblies/release2/annotation/cat/HG00438_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111252038,
+    "filename": "HG00438_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00438"
@@ -7076,7 +7076,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG005/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG005-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 49721906,
     "filename": "AS-HOR+SF-vs-HG005-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -7084,9 +7084,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG005/assemblies/release2/annotation/cat/HG005_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61498805,
-    "filename": "HG005_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG005/assemblies/release2/annotation/cat/HG005_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 103691109,
+    "filename": "HG005_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG005"
@@ -7310,7 +7310,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG005/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG005-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 47646544,
     "filename": "AS-HOR+SF-vs-HG005-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -7318,9 +7318,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG005/assemblies/release2/annotation/cat/HG005_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 59813888,
-    "filename": "HG005_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG005/assemblies/release2/annotation/cat/HG005_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 100694727,
+    "filename": "HG005_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG005"
@@ -7516,9 +7516,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00544/assemblies/release2/annotation/cat/HG00544_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63086453,
-    "filename": "HG00544_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00544/assemblies/release2/annotation/cat/HG00544_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111078170,
+    "filename": "HG00544_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00544"
@@ -7669,9 +7669,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00544/assemblies/release2/annotation/cat/HG00544_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63098268,
-    "filename": "HG00544_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00544/assemblies/release2/annotation/cat/HG00544_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110912263,
+    "filename": "HG00544_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00544"
@@ -7822,9 +7822,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00558/assemblies/release2/annotation/cat/HG00558_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63224297,
-    "filename": "HG00558_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00558/assemblies/release2/annotation/cat/HG00558_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110849321,
+    "filename": "HG00558_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00558"
@@ -7975,9 +7975,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00558/assemblies/release2/annotation/cat/HG00558_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63455908,
-    "filename": "HG00558_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00558/assemblies/release2/annotation/cat/HG00558_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111225110,
+    "filename": "HG00558_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00558"
@@ -8128,9 +8128,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00597/assemblies/release2/annotation/cat/HG00597_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63755291,
-    "filename": "HG00597_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00597/assemblies/release2/annotation/cat/HG00597_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112223653,
+    "filename": "HG00597_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00597"
@@ -8281,9 +8281,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00597/assemblies/release2/annotation/cat/HG00597_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63559026,
-    "filename": "HG00597_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00597/assemblies/release2/annotation/cat/HG00597_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111626974,
+    "filename": "HG00597_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00597"
@@ -8434,9 +8434,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00609/assemblies/release2/annotation/cat/HG00609_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63419739,
-    "filename": "HG00609_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00609/assemblies/release2/annotation/cat/HG00609_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111715476,
+    "filename": "HG00609_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00609"
@@ -8587,9 +8587,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00609/assemblies/release2/annotation/cat/HG00609_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61783498,
-    "filename": "HG00609_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00609/assemblies/release2/annotation/cat/HG00609_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108950941,
+    "filename": "HG00609_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00609"
@@ -8741,7 +8741,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG00621/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00621-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 49950273,
     "filename": "AS-HOR+SF-vs-HG00621-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -8749,9 +8749,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00621/assemblies/release2/annotation/cat/HG00621_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63207146,
-    "filename": "HG00621_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00621/assemblies/release2/annotation/cat/HG00621_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111058443,
+    "filename": "HG00621_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00621"
@@ -8993,7 +8993,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG00621/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00621-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 48192701,
     "filename": "AS-HOR+SF-vs-HG00621-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -9001,9 +9001,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00621/assemblies/release2/annotation/cat/HG00621_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61537972,
-    "filename": "HG00621_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00621/assemblies/release2/annotation/cat/HG00621_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 107983231,
+    "filename": "HG00621_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00621"
@@ -9217,9 +9217,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00639/assemblies/release2/annotation/cat/HG00639_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63474013,
-    "filename": "HG00639_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00639/assemblies/release2/annotation/cat/HG00639_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111655546,
+    "filename": "HG00639_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00639"
@@ -9370,9 +9370,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00639/assemblies/release2/annotation/cat/HG00639_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63259100,
-    "filename": "HG00639_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00639/assemblies/release2/annotation/cat/HG00639_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111534481,
+    "filename": "HG00639_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00639"
@@ -9523,9 +9523,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00642/assemblies/release2/annotation/cat/HG00642_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63328853,
-    "filename": "HG00642_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00642/assemblies/release2/annotation/cat/HG00642_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112044332,
+    "filename": "HG00642_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00642"
@@ -9676,9 +9676,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00642/assemblies/release2/annotation/cat/HG00642_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61910603,
-    "filename": "HG00642_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00642/assemblies/release2/annotation/cat/HG00642_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 109063519,
+    "filename": "HG00642_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00642"
@@ -9829,9 +9829,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00658/assemblies/release2/annotation/cat/HG00658_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63460783,
-    "filename": "HG00658_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00658/assemblies/release2/annotation/cat/HG00658_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111637485,
+    "filename": "HG00658_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00658"
@@ -9982,9 +9982,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00658/assemblies/release2/annotation/cat/HG00658_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61722547,
-    "filename": "HG00658_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00658/assemblies/release2/annotation/cat/HG00658_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108523212,
+    "filename": "HG00658_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00658"
@@ -10136,7 +10136,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG00673/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00673-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 54640824,
     "filename": "AS-HOR+SF-vs-HG00673-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -10144,9 +10144,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00673/assemblies/release2/annotation/cat/HG00673_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63076369,
-    "filename": "HG00673_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00673/assemblies/release2/annotation/cat/HG00673_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110121326,
+    "filename": "HG00673_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00673"
@@ -10388,7 +10388,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG00673/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00673-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 49457289,
     "filename": "AS-HOR+SF-vs-HG00673-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -10396,9 +10396,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00673/assemblies/release2/annotation/cat/HG00673_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61681249,
-    "filename": "HG00673_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00673/assemblies/release2/annotation/cat/HG00673_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 107750976,
+    "filename": "HG00673_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00673"
@@ -10612,9 +10612,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00706/assemblies/release2/annotation/cat/HG00706_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63382005,
-    "filename": "HG00706_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00706/assemblies/release2/annotation/cat/HG00706_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112178610,
+    "filename": "HG00706_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00706"
@@ -10765,9 +10765,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00706/assemblies/release2/annotation/cat/HG00706_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61543171,
-    "filename": "HG00706_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00706/assemblies/release2/annotation/cat/HG00706_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 109169885,
+    "filename": "HG00706_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00706"
@@ -10919,7 +10919,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG00733/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00733-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 44744178,
     "filename": "AS-HOR+SF-vs-HG00733-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -10927,9 +10927,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG00733/assemblies/release2/annotation/cat/HG00733_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61885565,
-    "filename": "HG00733_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG00733/assemblies/release2/annotation/cat/HG00733_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 104281063,
+    "filename": "HG00733_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00733"
@@ -11171,7 +11171,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG00733/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00733-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 48297600,
     "filename": "AS-HOR+SF-vs-HG00733-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -11179,9 +11179,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG00733/assemblies/release2/annotation/cat/HG00733_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61789692,
-    "filename": "HG00733_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG00733/assemblies/release2/annotation/cat/HG00733_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 103914945,
+    "filename": "HG00733_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00733"
@@ -11396,7 +11396,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG00735/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00735-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 50878360,
     "filename": "AS-HOR+SF-vs-HG00735-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -11404,9 +11404,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00735/assemblies/release2/annotation/cat/HG00735_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63214109,
-    "filename": "HG00735_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00735/assemblies/release2/annotation/cat/HG00735_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110357169,
+    "filename": "HG00735_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00735"
@@ -11648,7 +11648,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG00735/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00735-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 48277913,
     "filename": "AS-HOR+SF-vs-HG00735-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -11656,9 +11656,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00735/assemblies/release2/annotation/cat/HG00735_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63259597,
-    "filename": "HG00735_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00735/assemblies/release2/annotation/cat/HG00735_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110566837,
+    "filename": "HG00735_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00735"
@@ -11872,9 +11872,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00738/assemblies/release2/annotation/cat/HG00738_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63410724,
-    "filename": "HG00738_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00738/assemblies/release2/annotation/cat/HG00738_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111285455,
+    "filename": "HG00738_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00738"
@@ -12025,9 +12025,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00738/assemblies/release2/annotation/cat/HG00738_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61491466,
-    "filename": "HG00738_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00738/assemblies/release2/annotation/cat/HG00738_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 107801938,
+    "filename": "HG00738_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00738"
@@ -12179,7 +12179,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG00741/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00741-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 46458721,
     "filename": "AS-HOR+SF-vs-HG00741-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -12187,9 +12187,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00741/assemblies/release2/annotation/cat/HG00741_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63157465,
-    "filename": "HG00741_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00741/assemblies/release2/annotation/cat/HG00741_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110399932,
+    "filename": "HG00741_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG00741"
@@ -12431,7 +12431,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG00741/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG00741-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 51191050,
     "filename": "AS-HOR+SF-vs-HG00741-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -12439,9 +12439,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00741/assemblies/release2/annotation/cat/HG00741_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 62988836,
-    "filename": "HG00741_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG00741/assemblies/release2/annotation/cat/HG00741_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110057191,
+    "filename": "HG00741_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG00741"
@@ -12656,7 +12656,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG01071/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01071-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 50196671,
     "filename": "AS-HOR+SF-vs-HG01071-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -12664,9 +12664,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01071/assemblies/release2/annotation/cat/HG01071_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63236298,
-    "filename": "HG01071_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01071/assemblies/release2/annotation/cat/HG01071_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110475283,
+    "filename": "HG01071_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01071"
@@ -12908,7 +12908,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG01071/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01071-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 50817650,
     "filename": "AS-HOR+SF-vs-HG01071-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -12916,9 +12916,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01071/assemblies/release2/annotation/cat/HG01071_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63163680,
-    "filename": "HG01071_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01071/assemblies/release2/annotation/cat/HG01071_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110711290,
+    "filename": "HG01071_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01071"
@@ -13132,9 +13132,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01074/assemblies/release2/annotation/cat/HG01074_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63101756,
-    "filename": "HG01074_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01074/assemblies/release2/annotation/cat/HG01074_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110859058,
+    "filename": "HG01074_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01074"
@@ -13285,9 +13285,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01074/assemblies/release2/annotation/cat/HG01074_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61370357,
-    "filename": "HG01074_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01074/assemblies/release2/annotation/cat/HG01074_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 107594118,
+    "filename": "HG01074_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01074"
@@ -13438,9 +13438,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01081/assemblies/release2/annotation/cat/HG01081_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63328424,
-    "filename": "HG01081_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01081/assemblies/release2/annotation/cat/HG01081_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111557241,
+    "filename": "HG01081_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01081"
@@ -13591,9 +13591,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01081/assemblies/release2/annotation/cat/HG01081_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63192178,
-    "filename": "HG01081_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01081/assemblies/release2/annotation/cat/HG01081_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111192883,
+    "filename": "HG01081_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01081"
@@ -13744,9 +13744,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01099/assemblies/release2/annotation/cat/HG01099_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63141209,
-    "filename": "HG01099_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01099/assemblies/release2/annotation/cat/HG01099_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110390731,
+    "filename": "HG01099_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01099"
@@ -13897,9 +13897,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01099/assemblies/release2/annotation/cat/HG01099_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61540379,
-    "filename": "HG01099_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01099/assemblies/release2/annotation/cat/HG01099_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 107802453,
+    "filename": "HG01099_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01099"
@@ -14051,7 +14051,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG01106/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01106-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 48433779,
     "filename": "AS-HOR+SF-vs-HG01106-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -14059,9 +14059,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01106/assemblies/release2/annotation/cat/HG01106_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63160059,
-    "filename": "HG01106_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01106/assemblies/release2/annotation/cat/HG01106_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110746421,
+    "filename": "HG01106_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01106"
@@ -14303,7 +14303,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG01106/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01106-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 47176202,
     "filename": "AS-HOR+SF-vs-HG01106-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -14311,9 +14311,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01106/assemblies/release2/annotation/cat/HG01106_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61635483,
-    "filename": "HG01106_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01106/assemblies/release2/annotation/cat/HG01106_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108095420,
+    "filename": "HG01106_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01106"
@@ -14528,7 +14528,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG01109/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01109-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 49164014,
     "filename": "AS-HOR+SF-vs-HG01109-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -14536,9 +14536,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG01109/assemblies/release2/annotation/cat/HG01109_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61759651,
-    "filename": "HG01109_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG01109/assemblies/release2/annotation/cat/HG01109_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 104124905,
+    "filename": "HG01109_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01109"
@@ -14780,7 +14780,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG01109/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01109-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 43497915,
     "filename": "AS-HOR+SF-vs-HG01109-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -14788,9 +14788,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG01109/assemblies/release2/annotation/cat/HG01109_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 60129648,
-    "filename": "HG01109_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG01109/assemblies/release2/annotation/cat/HG01109_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 101053890,
+    "filename": "HG01109_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01109"
@@ -15005,7 +15005,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG01123/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01123-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 50286691,
     "filename": "AS-HOR+SF-vs-HG01123-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -15013,9 +15013,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01123/assemblies/release2/annotation/cat/HG01123_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61622019,
-    "filename": "HG01123_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01123/assemblies/release2/annotation/cat/HG01123_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 103810611,
+    "filename": "HG01123_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01123"
@@ -15257,7 +15257,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG01123/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01123-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 49046347,
     "filename": "AS-HOR+SF-vs-HG01123-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -15265,9 +15265,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01123/assemblies/release2/annotation/cat/HG01123_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61771763,
-    "filename": "HG01123_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01123/assemblies/release2/annotation/cat/HG01123_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 103999805,
+    "filename": "HG01123_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01123"
@@ -15481,9 +15481,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01150/assemblies/release2/annotation/cat/HG01150_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63339348,
-    "filename": "HG01150_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01150/assemblies/release2/annotation/cat/HG01150_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111782577,
+    "filename": "HG01150_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01150"
@@ -15634,9 +15634,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01150/assemblies/release2/annotation/cat/HG01150_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63486179,
-    "filename": "HG01150_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01150/assemblies/release2/annotation/cat/HG01150_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111785976,
+    "filename": "HG01150_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01150"
@@ -15787,9 +15787,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01167/assemblies/release2/annotation/cat/HG01167_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63229432,
-    "filename": "HG01167_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01167/assemblies/release2/annotation/cat/HG01167_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110882769,
+    "filename": "HG01167_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01167"
@@ -15940,9 +15940,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01167/assemblies/release2/annotation/cat/HG01167_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61764575,
-    "filename": "HG01167_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01167/assemblies/release2/annotation/cat/HG01167_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108243650,
+    "filename": "HG01167_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01167"
@@ -16094,7 +16094,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG01175/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01175-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 49426223,
     "filename": "AS-HOR+SF-vs-HG01175-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -16102,9 +16102,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01175/assemblies/release2/annotation/cat/HG01175_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63302509,
-    "filename": "HG01175_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01175/assemblies/release2/annotation/cat/HG01175_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110968183,
+    "filename": "HG01175_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01175"
@@ -16346,7 +16346,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG01175/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01175-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 49925648,
     "filename": "AS-HOR+SF-vs-HG01175-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -16354,9 +16354,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01175/assemblies/release2/annotation/cat/HG01175_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63156984,
-    "filename": "HG01175_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01175/assemblies/release2/annotation/cat/HG01175_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110808583,
+    "filename": "HG01175_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01175"
@@ -16570,9 +16570,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01192/assemblies/release2/annotation/cat/HG01192_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63375125,
-    "filename": "HG01192_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01192/assemblies/release2/annotation/cat/HG01192_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111074762,
+    "filename": "HG01192_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01192"
@@ -16723,9 +16723,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01192/assemblies/release2/annotation/cat/HG01192_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61788448,
-    "filename": "HG01192_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01192/assemblies/release2/annotation/cat/HG01192_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108156531,
+    "filename": "HG01192_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01192"
@@ -16877,7 +16877,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG01243/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01243-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 50881072,
     "filename": "AS-HOR+SF-vs-HG01243-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -16885,9 +16885,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG01243/assemblies/release2/annotation/cat/HG01243_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61689853,
-    "filename": "HG01243_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG01243/assemblies/release2/annotation/cat/HG01243_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 103903907,
+    "filename": "HG01243_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01243"
@@ -17129,7 +17129,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG01243/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01243-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 44064586,
     "filename": "AS-HOR+SF-vs-HG01243-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -17137,9 +17137,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG01243/assemblies/release2/annotation/cat/HG01243_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 60054461,
-    "filename": "HG01243_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG01243/assemblies/release2/annotation/cat/HG01243_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 101026086,
+    "filename": "HG01243_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01243"
@@ -17353,9 +17353,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01252/assemblies/release2/annotation/cat/HG01252_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63335642,
-    "filename": "HG01252_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01252/assemblies/release2/annotation/cat/HG01252_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111681251,
+    "filename": "HG01252_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01252"
@@ -17506,9 +17506,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01252/assemblies/release2/annotation/cat/HG01252_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61673743,
-    "filename": "HG01252_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01252/assemblies/release2/annotation/cat/HG01252_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108688298,
+    "filename": "HG01252_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01252"
@@ -17659,9 +17659,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01255/assemblies/release2/annotation/cat/HG01255_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63215295,
-    "filename": "HG01255_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01255/assemblies/release2/annotation/cat/HG01255_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111711127,
+    "filename": "HG01255_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01255"
@@ -17812,9 +17812,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01255/assemblies/release2/annotation/cat/HG01255_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61422126,
-    "filename": "HG01255_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01255/assemblies/release2/annotation/cat/HG01255_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108451521,
+    "filename": "HG01255_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01255"
@@ -17966,7 +17966,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG01258/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01258-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 49995925,
     "filename": "AS-HOR+SF-vs-HG01258-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -17974,9 +17974,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01258/assemblies/release2/annotation/cat/HG01258_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63356383,
-    "filename": "HG01258_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01258/assemblies/release2/annotation/cat/HG01258_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 113708599,
+    "filename": "HG01258_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01258"
@@ -18218,7 +18218,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG01258/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01258-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 47087592,
     "filename": "AS-HOR+SF-vs-HG01258-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -18226,9 +18226,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01258/assemblies/release2/annotation/cat/HG01258_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61485554,
-    "filename": "HG01258_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01258/assemblies/release2/annotation/cat/HG01258_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110230904,
+    "filename": "HG01258_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01258"
@@ -18442,9 +18442,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01261/assemblies/release2/annotation/cat/HG01261_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63198860,
-    "filename": "HG01261_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01261/assemblies/release2/annotation/cat/HG01261_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110949327,
+    "filename": "HG01261_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01261"
@@ -18595,9 +18595,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01261/assemblies/release2/annotation/cat/HG01261_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61564073,
-    "filename": "HG01261_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01261/assemblies/release2/annotation/cat/HG01261_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 107782627,
+    "filename": "HG01261_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01261"
@@ -18748,9 +18748,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01346/assemblies/release2/annotation/cat/HG01346_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63630022,
-    "filename": "HG01346_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01346/assemblies/release2/annotation/cat/HG01346_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 113445954,
+    "filename": "HG01346_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01346"
@@ -18901,9 +18901,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01346/assemblies/release2/annotation/cat/HG01346_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63675339,
-    "filename": "HG01346_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01346/assemblies/release2/annotation/cat/HG01346_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 113681408,
+    "filename": "HG01346_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01346"
@@ -19055,7 +19055,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG01358/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01358-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 45153278,
     "filename": "AS-HOR+SF-vs-HG01358-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -19063,9 +19063,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01358/assemblies/release2/annotation/cat/HG01358_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63052976,
-    "filename": "HG01358_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01358/assemblies/release2/annotation/cat/HG01358_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112072866,
+    "filename": "HG01358_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01358"
@@ -19307,7 +19307,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG01358/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01358-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 46955549,
     "filename": "AS-HOR+SF-vs-HG01358-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -19315,9 +19315,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01358/assemblies/release2/annotation/cat/HG01358_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61785574,
-    "filename": "HG01358_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01358/assemblies/release2/annotation/cat/HG01358_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 109634093,
+    "filename": "HG01358_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01358"
@@ -19532,7 +19532,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG01361/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01361-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 44636821,
     "filename": "AS-HOR+SF-vs-HG01361-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -19540,9 +19540,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01361/assemblies/release2/annotation/cat/HG01361_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63220161,
-    "filename": "HG01361_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01361/assemblies/release2/annotation/cat/HG01361_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112257333,
+    "filename": "HG01361_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01361"
@@ -19784,7 +19784,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG01361/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01361-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 47172337,
     "filename": "AS-HOR+SF-vs-HG01361-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -19792,9 +19792,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01361/assemblies/release2/annotation/cat/HG01361_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63383867,
-    "filename": "HG01361_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01361/assemblies/release2/annotation/cat/HG01361_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112417104,
+    "filename": "HG01361_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01361"
@@ -20008,9 +20008,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01433/assemblies/release2/annotation/cat/HG01433_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63350553,
-    "filename": "HG01433_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01433/assemblies/release2/annotation/cat/HG01433_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111711355,
+    "filename": "HG01433_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01433"
@@ -20161,9 +20161,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01433/assemblies/release2/annotation/cat/HG01433_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61800394,
-    "filename": "HG01433_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01433/assemblies/release2/annotation/cat/HG01433_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108777165,
+    "filename": "HG01433_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01433"
@@ -20314,9 +20314,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01496/assemblies/release2/annotation/cat/HG01496_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63358176,
-    "filename": "HG01496_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01496/assemblies/release2/annotation/cat/HG01496_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111927377,
+    "filename": "HG01496_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01496"
@@ -20467,9 +20467,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01496/assemblies/release2/annotation/cat/HG01496_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63492360,
-    "filename": "HG01496_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01496/assemblies/release2/annotation/cat/HG01496_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112085725,
+    "filename": "HG01496_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01496"
@@ -20620,9 +20620,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01530/assemblies/release2/annotation/cat/HG01530_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63231634,
-    "filename": "HG01530_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01530/assemblies/release2/annotation/cat/HG01530_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111506930,
+    "filename": "HG01530_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01530"
@@ -20773,9 +20773,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01530/assemblies/release2/annotation/cat/HG01530_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61785068,
-    "filename": "HG01530_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01530/assemblies/release2/annotation/cat/HG01530_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108863782,
+    "filename": "HG01530_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01530"
@@ -20926,9 +20926,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01784/assemblies/release2/annotation/cat/HG01784_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63484551,
-    "filename": "HG01784_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01784/assemblies/release2/annotation/cat/HG01784_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112095052,
+    "filename": "HG01784_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01784"
@@ -21079,9 +21079,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01784/assemblies/release2/annotation/cat/HG01784_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63611831,
-    "filename": "HG01784_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01784/assemblies/release2/annotation/cat/HG01784_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112239333,
+    "filename": "HG01784_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01784"
@@ -21232,9 +21232,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01786/assemblies/release2/annotation/cat/HG01786_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63425432,
-    "filename": "HG01786_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01786/assemblies/release2/annotation/cat/HG01786_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111478126,
+    "filename": "HG01786_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01786"
@@ -21385,9 +21385,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01786/assemblies/release2/annotation/cat/HG01786_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63380413,
-    "filename": "HG01786_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01786/assemblies/release2/annotation/cat/HG01786_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111464937,
+    "filename": "HG01786_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01786"
@@ -21538,9 +21538,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01884/assemblies/release2/annotation/cat/HG01884_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63151899,
-    "filename": "HG01884_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01884/assemblies/release2/annotation/cat/HG01884_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111252828,
+    "filename": "HG01884_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01884"
@@ -21691,9 +21691,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01884/assemblies/release2/annotation/cat/HG01884_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63320260,
-    "filename": "HG01884_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01884/assemblies/release2/annotation/cat/HG01884_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111387413,
+    "filename": "HG01884_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01884"
@@ -21845,7 +21845,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG01891/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01891-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 47084127,
     "filename": "AS-HOR+SF-vs-HG01891-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -21853,9 +21853,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01891/assemblies/release2/annotation/cat/HG01891_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63761469,
-    "filename": "HG01891_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01891/assemblies/release2/annotation/cat/HG01891_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 114636027,
+    "filename": "HG01891_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01891"
@@ -22097,7 +22097,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG01891/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01891-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 45720941,
     "filename": "AS-HOR+SF-vs-HG01891-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -22105,9 +22105,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01891/assemblies/release2/annotation/cat/HG01891_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63622756,
-    "filename": "HG01891_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01891/assemblies/release2/annotation/cat/HG01891_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 114344126,
+    "filename": "HG01891_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01891"
@@ -22322,7 +22322,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG01928/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01928-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 45410705,
     "filename": "AS-HOR+SF-vs-HG01928-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -22330,9 +22330,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01928/assemblies/release2/annotation/cat/HG01928_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63193855,
-    "filename": "HG01928_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01928/assemblies/release2/annotation/cat/HG01928_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110940058,
+    "filename": "HG01928_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01928"
@@ -22574,7 +22574,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG01928/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01928-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 50184564,
     "filename": "AS-HOR+SF-vs-HG01928-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -22582,9 +22582,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01928/assemblies/release2/annotation/cat/HG01928_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61564614,
-    "filename": "HG01928_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01928/assemblies/release2/annotation/cat/HG01928_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 107952643,
+    "filename": "HG01928_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01928"
@@ -22798,9 +22798,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01934/assemblies/release2/annotation/cat/HG01934_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63408359,
-    "filename": "HG01934_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01934/assemblies/release2/annotation/cat/HG01934_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111856184,
+    "filename": "HG01934_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01934"
@@ -22951,9 +22951,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01934/assemblies/release2/annotation/cat/HG01934_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61540617,
-    "filename": "HG01934_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01934/assemblies/release2/annotation/cat/HG01934_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108548855,
+    "filename": "HG01934_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01934"
@@ -23104,9 +23104,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01940/assemblies/release2/annotation/cat/HG01940_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63406720,
-    "filename": "HG01940_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01940/assemblies/release2/annotation/cat/HG01940_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111815971,
+    "filename": "HG01940_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01940"
@@ -23257,9 +23257,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01940/assemblies/release2/annotation/cat/HG01940_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63352737,
-    "filename": "HG01940_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01940/assemblies/release2/annotation/cat/HG01940_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111963689,
+    "filename": "HG01940_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01940"
@@ -23410,9 +23410,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01943/assemblies/release2/annotation/cat/HG01943_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63385845,
-    "filename": "HG01943_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01943/assemblies/release2/annotation/cat/HG01943_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111941501,
+    "filename": "HG01943_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01943"
@@ -23563,9 +23563,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01943/assemblies/release2/annotation/cat/HG01943_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61740336,
-    "filename": "HG01943_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01943/assemblies/release2/annotation/cat/HG01943_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108969405,
+    "filename": "HG01943_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01943"
@@ -23717,7 +23717,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG01952/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01952-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 48944999,
     "filename": "AS-HOR+SF-vs-HG01952-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -23725,9 +23725,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01952/assemblies/release2/annotation/cat/HG01952_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63281910,
-    "filename": "HG01952_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01952/assemblies/release2/annotation/cat/HG01952_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111028815,
+    "filename": "HG01952_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01952"
@@ -23969,7 +23969,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG01952/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01952-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 45844889,
     "filename": "AS-HOR+SF-vs-HG01952-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -23977,9 +23977,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01952/assemblies/release2/annotation/cat/HG01952_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61504419,
-    "filename": "HG01952_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01952/assemblies/release2/annotation/cat/HG01952_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 107800663,
+    "filename": "HG01952_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01952"
@@ -24193,9 +24193,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01960/assemblies/release2/annotation/cat/HG01960_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63375489,
-    "filename": "HG01960_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01960/assemblies/release2/annotation/cat/HG01960_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111372393,
+    "filename": "HG01960_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01960"
@@ -24346,9 +24346,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01960/assemblies/release2/annotation/cat/HG01960_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63491289,
-    "filename": "HG01960_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01960/assemblies/release2/annotation/cat/HG01960_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111512143,
+    "filename": "HG01960_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01960"
@@ -24499,9 +24499,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01969/assemblies/release2/annotation/cat/HG01969_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63262782,
-    "filename": "HG01969_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01969/assemblies/release2/annotation/cat/HG01969_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110824559,
+    "filename": "HG01969_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01969"
@@ -24652,9 +24652,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01969/assemblies/release2/annotation/cat/HG01969_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63295274,
-    "filename": "HG01969_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01969/assemblies/release2/annotation/cat/HG01969_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110811361,
+    "filename": "HG01969_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01969"
@@ -24805,9 +24805,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01975/assemblies/release2/annotation/cat/HG01975_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63499823,
-    "filename": "HG01975_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01975/assemblies/release2/annotation/cat/HG01975_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112229027,
+    "filename": "HG01975_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01975"
@@ -24958,9 +24958,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01975/assemblies/release2/annotation/cat/HG01975_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63657132,
-    "filename": "HG01975_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01975/assemblies/release2/annotation/cat/HG01975_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112591220,
+    "filename": "HG01975_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01975"
@@ -25112,7 +25112,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG01978/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01978-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 52985601,
     "filename": "AS-HOR+SF-vs-HG01978-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -25120,9 +25120,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01978/assemblies/release2/annotation/cat/HG01978_mat_hprc_r2_v1.1.0_cat_v1.1.gff3.gz",
-    "fileSize": 63180407,
-    "filename": "HG01978_mat_hprc_r2_v1.1.0_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01978/assemblies/release2/annotation/cat/HG01978_mat_hprc_r2_v1.1.0_cat_v1.3.gff3.gz",
+    "fileSize": 110691899,
+    "filename": "HG01978_mat_hprc_r2_v1.1.0_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01978"
@@ -25364,7 +25364,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG01978/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG01978-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 52284898,
     "filename": "AS-HOR+SF-vs-HG01978-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -25372,9 +25372,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01978/assemblies/release2/annotation/cat/HG01978_pat_hprc_r2_v1.1.0_cat_v1.1.gff3.gz",
-    "fileSize": 63220541,
-    "filename": "HG01978_pat_hprc_r2_v1.1.0_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01978/assemblies/release2/annotation/cat/HG01978_pat_hprc_r2_v1.1.0_cat_v1.3.gff3.gz",
+    "fileSize": 110957332,
+    "filename": "HG01978_pat_hprc_r2_v1.1.0_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01978"
@@ -25588,9 +25588,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01981/assemblies/release2/annotation/cat/HG01981_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63505629,
-    "filename": "HG01981_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01981/assemblies/release2/annotation/cat/HG01981_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111942318,
+    "filename": "HG01981_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01981"
@@ -25741,9 +25741,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01981/assemblies/release2/annotation/cat/HG01981_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63556623,
-    "filename": "HG01981_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01981/assemblies/release2/annotation/cat/HG01981_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112241656,
+    "filename": "HG01981_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01981"
@@ -25894,9 +25894,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01993/assemblies/release2/annotation/cat/HG01993_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63432937,
-    "filename": "HG01993_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01993/assemblies/release2/annotation/cat/HG01993_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111766139,
+    "filename": "HG01993_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG01993"
@@ -26047,9 +26047,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01993/assemblies/release2/annotation/cat/HG01993_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63356401,
-    "filename": "HG01993_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG01993/assemblies/release2/annotation/cat/HG01993_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111754952,
+    "filename": "HG01993_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG01993"
@@ -26200,9 +26200,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02004/assemblies/release2/annotation/cat/HG02004_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63170284,
-    "filename": "HG02004_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02004/assemblies/release2/annotation/cat/HG02004_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110847933,
+    "filename": "HG02004_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02004"
@@ -26353,9 +26353,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02004/assemblies/release2/annotation/cat/HG02004_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63232837,
-    "filename": "HG02004_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02004/assemblies/release2/annotation/cat/HG02004_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111168176,
+    "filename": "HG02004_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02004"
@@ -26506,9 +26506,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02015/assemblies/release2/annotation/cat/HG02015_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63517216,
-    "filename": "HG02015_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02015/assemblies/release2/annotation/cat/HG02015_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111758999,
+    "filename": "HG02015_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02015"
@@ -26659,9 +26659,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02015/assemblies/release2/annotation/cat/HG02015_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61721144,
-    "filename": "HG02015_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02015/assemblies/release2/annotation/cat/HG02015_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108630889,
+    "filename": "HG02015_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02015"
@@ -26812,9 +26812,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02027/assemblies/release2/annotation/cat/HG02027_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63183397,
-    "filename": "HG02027_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02027/assemblies/release2/annotation/cat/HG02027_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110037897,
+    "filename": "HG02027_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02027"
@@ -26965,9 +26965,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02027/assemblies/release2/annotation/cat/HG02027_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61337892,
-    "filename": "HG02027_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02027/assemblies/release2/annotation/cat/HG02027_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 106769556,
+    "filename": "HG02027_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02027"
@@ -27118,9 +27118,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02040/assemblies/release2/annotation/cat/HG02040_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63680721,
-    "filename": "HG02040_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02040/assemblies/release2/annotation/cat/HG02040_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112700100,
+    "filename": "HG02040_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02040"
@@ -27271,9 +27271,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02040/assemblies/release2/annotation/cat/HG02040_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61853903,
-    "filename": "HG02040_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02040/assemblies/release2/annotation/cat/HG02040_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 109552316,
+    "filename": "HG02040_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02040"
@@ -27425,7 +27425,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02055/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02055-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 45862415,
     "filename": "AS-HOR+SF-vs-HG02055-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -27433,9 +27433,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02055/assemblies/release2/annotation/cat/HG02055_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61680629,
-    "filename": "HG02055_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02055/assemblies/release2/annotation/cat/HG02055_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 104020785,
+    "filename": "HG02055_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02055"
@@ -27677,7 +27677,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02055/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02055-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 48829964,
     "filename": "AS-HOR+SF-vs-HG02055-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -27685,9 +27685,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02055/assemblies/release2/annotation/cat/HG02055_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 60203968,
-    "filename": "HG02055_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02055/assemblies/release2/annotation/cat/HG02055_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 101279937,
+    "filename": "HG02055_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02055"
@@ -27901,9 +27901,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02056/assemblies/release2/annotation/cat/HG02056_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63530526,
-    "filename": "HG02056_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02056/assemblies/release2/annotation/cat/HG02056_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112174813,
+    "filename": "HG02056_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02056"
@@ -28054,9 +28054,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02056/assemblies/release2/annotation/cat/HG02056_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61969889,
-    "filename": "HG02056_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02056/assemblies/release2/annotation/cat/HG02056_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 109178984,
+    "filename": "HG02056_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02056"
@@ -28207,9 +28207,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02071/assemblies/release2/annotation/cat/HG02071_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63520856,
-    "filename": "HG02071_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02071/assemblies/release2/annotation/cat/HG02071_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111489673,
+    "filename": "HG02071_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02071"
@@ -28360,9 +28360,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02071/assemblies/release2/annotation/cat/HG02071_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61649802,
-    "filename": "HG02071_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02071/assemblies/release2/annotation/cat/HG02071_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108286328,
+    "filename": "HG02071_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02071"
@@ -28513,9 +28513,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02074/assemblies/release2/annotation/cat/HG02074_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63360200,
-    "filename": "HG02074_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02074/assemblies/release2/annotation/cat/HG02074_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110908108,
+    "filename": "HG02074_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02074"
@@ -28666,9 +28666,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02074/assemblies/release2/annotation/cat/HG02074_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61806970,
-    "filename": "HG02074_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02074/assemblies/release2/annotation/cat/HG02074_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108238828,
+    "filename": "HG02074_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02074"
@@ -28820,7 +28820,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02080/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02080-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 49430867,
     "filename": "AS-HOR+SF-vs-HG02080-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -28828,9 +28828,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02080/assemblies/release2/annotation/cat/HG02080_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61759944,
-    "filename": "HG02080_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02080/assemblies/release2/annotation/cat/HG02080_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 104027519,
+    "filename": "HG02080_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02080"
@@ -29072,7 +29072,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02080/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02080-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 46447052,
     "filename": "AS-HOR+SF-vs-HG02080-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -29080,9 +29080,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02080/assemblies/release2/annotation/cat/HG02080_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61782782,
-    "filename": "HG02080_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02080/assemblies/release2/annotation/cat/HG02080_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 104054814,
+    "filename": "HG02080_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02080"
@@ -29296,9 +29296,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02083/assemblies/release2/annotation/cat/HG02083_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63287980,
-    "filename": "HG02083_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02083/assemblies/release2/annotation/cat/HG02083_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111227824,
+    "filename": "HG02083_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02083"
@@ -29449,9 +29449,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02083/assemblies/release2/annotation/cat/HG02083_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61796802,
-    "filename": "HG02083_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02083/assemblies/release2/annotation/cat/HG02083_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108430734,
+    "filename": "HG02083_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02083"
@@ -29603,7 +29603,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02109/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02109-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 42906796,
     "filename": "AS-HOR+SF-vs-HG02109-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -29611,9 +29611,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02109/assemblies/release2/annotation/cat/HG02109_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61610857,
-    "filename": "HG02109_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02109/assemblies/release2/annotation/cat/HG02109_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 103889003,
+    "filename": "HG02109_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02109"
@@ -29855,7 +29855,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02109/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02109-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 47904115,
     "filename": "AS-HOR+SF-vs-HG02109-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -29863,9 +29863,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02109/assemblies/release2/annotation/cat/HG02109_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61586163,
-    "filename": "HG02109_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02109/assemblies/release2/annotation/cat/HG02109_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 103888472,
+    "filename": "HG02109_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02109"
@@ -30079,9 +30079,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02129/assemblies/release2/annotation/cat/HG02129_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63559942,
-    "filename": "HG02129_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02129/assemblies/release2/annotation/cat/HG02129_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112286995,
+    "filename": "HG02129_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02129"
@@ -30232,9 +30232,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02129/assemblies/release2/annotation/cat/HG02129_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 62010384,
-    "filename": "HG02129_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02129/assemblies/release2/annotation/cat/HG02129_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 109781147,
+    "filename": "HG02129_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02129"
@@ -30385,9 +30385,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02132/assemblies/release2/annotation/cat/HG02132_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63097558,
-    "filename": "HG02132_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02132/assemblies/release2/annotation/cat/HG02132_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110556000,
+    "filename": "HG02132_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02132"
@@ -30538,9 +30538,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02132/assemblies/release2/annotation/cat/HG02132_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61505709,
-    "filename": "HG02132_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02132/assemblies/release2/annotation/cat/HG02132_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 107310220,
+    "filename": "HG02132_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02132"
@@ -30691,9 +30691,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02135/assemblies/release2/annotation/cat/HG02135_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63183119,
-    "filename": "HG02135_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02135/assemblies/release2/annotation/cat/HG02135_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110251742,
+    "filename": "HG02135_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02135"
@@ -30844,9 +30844,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02135/assemblies/release2/annotation/cat/HG02135_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61575994,
-    "filename": "HG02135_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02135/assemblies/release2/annotation/cat/HG02135_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 107432302,
+    "filename": "HG02135_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02135"
@@ -30998,7 +30998,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02145/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02145-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 47533974,
     "filename": "AS-HOR+SF-vs-HG02145-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -31006,9 +31006,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02145/assemblies/release2/annotation/cat/HG02145_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61702419,
-    "filename": "HG02145_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02145/assemblies/release2/annotation/cat/HG02145_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 104060485,
+    "filename": "HG02145_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02145"
@@ -31250,7 +31250,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02145/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02145-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 46883900,
     "filename": "AS-HOR+SF-vs-HG02145-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -31258,9 +31258,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02145/assemblies/release2/annotation/cat/HG02145_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 60054640,
-    "filename": "HG02145_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02145/assemblies/release2/annotation/cat/HG02145_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 101285527,
+    "filename": "HG02145_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02145"
@@ -31475,7 +31475,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG02148/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02148-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 51628971,
     "filename": "AS-HOR+SF-vs-HG02148-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -31483,9 +31483,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02148/assemblies/release2/annotation/cat/HG02148_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63203634,
-    "filename": "HG02148_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02148/assemblies/release2/annotation/cat/HG02148_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111204801,
+    "filename": "HG02148_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02148"
@@ -31727,7 +31727,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG02148/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02148-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 46484093,
     "filename": "AS-HOR+SF-vs-HG02148-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -31735,9 +31735,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02148/assemblies/release2/annotation/cat/HG02148_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63324846,
-    "filename": "HG02148_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02148/assemblies/release2/annotation/cat/HG02148_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111296268,
+    "filename": "HG02148_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02148"
@@ -31951,9 +31951,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02155/assemblies/release2/annotation/cat/HG02155_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63488337,
-    "filename": "HG02155_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02155/assemblies/release2/annotation/cat/HG02155_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112038857,
+    "filename": "HG02155_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02155"
@@ -32104,9 +32104,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02155/assemblies/release2/annotation/cat/HG02155_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63427667,
-    "filename": "HG02155_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02155/assemblies/release2/annotation/cat/HG02155_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112117698,
+    "filename": "HG02155_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02155"
@@ -32257,9 +32257,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02165/assemblies/release2/annotation/cat/HG02165_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63216116,
-    "filename": "HG02165_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02165/assemblies/release2/annotation/cat/HG02165_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110454119,
+    "filename": "HG02165_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02165"
@@ -32410,9 +32410,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02165/assemblies/release2/annotation/cat/HG02165_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63387136,
-    "filename": "HG02165_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02165/assemblies/release2/annotation/cat/HG02165_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110634028,
+    "filename": "HG02165_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02165"
@@ -32563,9 +32563,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02178/assemblies/release2/annotation/cat/HG02178_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63582749,
-    "filename": "HG02178_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02178/assemblies/release2/annotation/cat/HG02178_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112015368,
+    "filename": "HG02178_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02178"
@@ -32716,9 +32716,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02178/assemblies/release2/annotation/cat/HG02178_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63260191,
-    "filename": "HG02178_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02178/assemblies/release2/annotation/cat/HG02178_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111547503,
+    "filename": "HG02178_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02178"
@@ -32870,7 +32870,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG02257/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02257-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 46353345,
     "filename": "AS-HOR+SF-vs-HG02257-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -32878,9 +32878,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02257/assemblies/release2/annotation/cat/HG02257_mat_hprc_r2_v1.1.0_cat_v1.1.gff3.gz",
-    "fileSize": 63752966,
-    "filename": "HG02257_mat_hprc_r2_v1.1.0_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02257/assemblies/release2/annotation/cat/HG02257_mat_hprc_r2_v1.1.0_cat_v1.3.gff3.gz",
+    "fileSize": 114105951,
+    "filename": "HG02257_mat_hprc_r2_v1.1.0_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02257"
@@ -33122,7 +33122,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG02257/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02257-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 45087588,
     "filename": "AS-HOR+SF-vs-HG02257-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -33130,9 +33130,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02257/assemblies/release2/annotation/cat/HG02257_pat_hprc_r2_v1.1.0_cat_v1.1.gff3.gz",
-    "fileSize": 63550666,
-    "filename": "HG02257_pat_hprc_r2_v1.1.0_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02257/assemblies/release2/annotation/cat/HG02257_pat_hprc_r2_v1.1.0_cat_v1.3.gff3.gz",
+    "fileSize": 113792323,
+    "filename": "HG02257_pat_hprc_r2_v1.1.0_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02257"
@@ -33346,9 +33346,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02258/assemblies/release2/annotation/cat/HG02258_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63495257,
-    "filename": "HG02258_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02258/assemblies/release2/annotation/cat/HG02258_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112411076,
+    "filename": "HG02258_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02258"
@@ -33499,9 +33499,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02258/assemblies/release2/annotation/cat/HG02258_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61914895,
-    "filename": "HG02258_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02258/assemblies/release2/annotation/cat/HG02258_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 109501753,
+    "filename": "HG02258_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02258"
@@ -33652,9 +33652,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02273/assemblies/release2/annotation/cat/HG02273_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63709205,
-    "filename": "HG02273_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02273/assemblies/release2/annotation/cat/HG02273_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112981609,
+    "filename": "HG02273_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02273"
@@ -33805,9 +33805,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02273/assemblies/release2/annotation/cat/HG02273_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 64027538,
-    "filename": "HG02273_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02273/assemblies/release2/annotation/cat/HG02273_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 113560715,
+    "filename": "HG02273_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02273"
@@ -33958,9 +33958,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02280/assemblies/release2/annotation/cat/HG02280_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63673333,
-    "filename": "HG02280_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02280/assemblies/release2/annotation/cat/HG02280_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112177024,
+    "filename": "HG02280_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02280"
@@ -34111,9 +34111,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02280/assemblies/release2/annotation/cat/HG02280_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63671152,
-    "filename": "HG02280_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02280/assemblies/release2/annotation/cat/HG02280_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112203656,
+    "filename": "HG02280_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02280"
@@ -34264,9 +34264,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02293/assemblies/release2/annotation/cat/HG02293_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63231151,
-    "filename": "HG02293_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02293/assemblies/release2/annotation/cat/HG02293_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110960920,
+    "filename": "HG02293_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02293"
@@ -34417,9 +34417,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02293/assemblies/release2/annotation/cat/HG02293_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63494112,
-    "filename": "HG02293_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02293/assemblies/release2/annotation/cat/HG02293_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111417163,
+    "filename": "HG02293_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02293"
@@ -34570,9 +34570,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02300/assemblies/release2/annotation/cat/HG02300_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63326962,
-    "filename": "HG02300_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02300/assemblies/release2/annotation/cat/HG02300_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111371941,
+    "filename": "HG02300_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02300"
@@ -34723,9 +34723,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02300/assemblies/release2/annotation/cat/HG02300_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63417136,
-    "filename": "HG02300_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02300/assemblies/release2/annotation/cat/HG02300_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111444019,
+    "filename": "HG02300_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02300"
@@ -34876,9 +34876,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02391/assemblies/release2/annotation/cat/HG02391_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63612702,
-    "filename": "HG02391_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02391/assemblies/release2/annotation/cat/HG02391_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112133382,
+    "filename": "HG02391_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02391"
@@ -35029,9 +35029,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02391/assemblies/release2/annotation/cat/HG02391_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61999110,
-    "filename": "HG02391_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02391/assemblies/release2/annotation/cat/HG02391_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 109083009,
+    "filename": "HG02391_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02391"
@@ -35182,9 +35182,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02392/assemblies/release2/annotation/cat/HG02392_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63450581,
-    "filename": "HG02392_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02392/assemblies/release2/annotation/cat/HG02392_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111757409,
+    "filename": "HG02392_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02392"
@@ -35335,9 +35335,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02392/assemblies/release2/annotation/cat/HG02392_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 62142102,
-    "filename": "HG02392_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02392/assemblies/release2/annotation/cat/HG02392_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 109493374,
+    "filename": "HG02392_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02392"
@@ -35488,9 +35488,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02451/assemblies/release2/annotation/cat/HG02451_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63033218,
-    "filename": "HG02451_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02451/assemblies/release2/annotation/cat/HG02451_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110166655,
+    "filename": "HG02451_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02451"
@@ -35641,9 +35641,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02451/assemblies/release2/annotation/cat/HG02451_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63196185,
-    "filename": "HG02451_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02451/assemblies/release2/annotation/cat/HG02451_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110231844,
+    "filename": "HG02451_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02451"
@@ -35795,7 +35795,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG02486/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02486-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 46777360,
     "filename": "AS-HOR+SF-vs-HG02486-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -35803,9 +35803,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02486/assemblies/release2/annotation/cat/HG02486_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61632149,
-    "filename": "HG02486_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02486/assemblies/release2/annotation/cat/HG02486_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 104051490,
+    "filename": "HG02486_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02486"
@@ -36047,7 +36047,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG02486/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02486-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 45794998,
     "filename": "AS-HOR+SF-vs-HG02486-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -36055,9 +36055,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02486/assemblies/release2/annotation/cat/HG02486_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 59941004,
-    "filename": "HG02486_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02486/assemblies/release2/annotation/cat/HG02486_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 100924391,
+    "filename": "HG02486_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02486"
@@ -36271,9 +36271,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02514/assemblies/release2/annotation/cat/HG02514_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63428731,
-    "filename": "HG02514_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02514/assemblies/release2/annotation/cat/HG02514_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111332451,
+    "filename": "HG02514_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02514"
@@ -36424,9 +36424,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02514/assemblies/release2/annotation/cat/HG02514_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61812039,
-    "filename": "HG02514_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02514/assemblies/release2/annotation/cat/HG02514_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108548944,
+    "filename": "HG02514_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02514"
@@ -36577,9 +36577,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02523/assemblies/release2/annotation/cat/HG02523_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63045714,
-    "filename": "HG02523_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02523/assemblies/release2/annotation/cat/HG02523_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110216121,
+    "filename": "HG02523_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02523"
@@ -36730,9 +36730,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02523/assemblies/release2/annotation/cat/HG02523_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63258294,
-    "filename": "HG02523_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02523/assemblies/release2/annotation/cat/HG02523_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110432594,
+    "filename": "HG02523_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02523"
@@ -36884,7 +36884,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG02559/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02559-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 46378147,
     "filename": "AS-HOR+SF-vs-HG02559-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -36892,9 +36892,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02559/assemblies/release2/annotation/cat/HG02559_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61800518,
-    "filename": "HG02559_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02559/assemblies/release2/annotation/cat/HG02559_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 104137454,
+    "filename": "HG02559_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02559"
@@ -37136,7 +37136,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG02559/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02559-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 46092531,
     "filename": "AS-HOR+SF-vs-HG02559-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -37144,9 +37144,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02559/assemblies/release2/annotation/cat/HG02559_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61730295,
-    "filename": "HG02559_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02559/assemblies/release2/annotation/cat/HG02559_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 104288467,
+    "filename": "HG02559_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02559"
@@ -37361,7 +37361,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG02572/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02572-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 52192979,
     "filename": "AS-HOR+SF-vs-HG02572-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -37369,9 +37369,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02572/assemblies/release2/annotation/cat/HG02572_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63468364,
-    "filename": "HG02572_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02572/assemblies/release2/annotation/cat/HG02572_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111741680,
+    "filename": "HG02572_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02572"
@@ -37613,7 +37613,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG02572/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02572-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 45988521,
     "filename": "AS-HOR+SF-vs-HG02572-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -37621,9 +37621,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02572/assemblies/release2/annotation/cat/HG02572_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61671329,
-    "filename": "HG02572_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02572/assemblies/release2/annotation/cat/HG02572_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108443070,
+    "filename": "HG02572_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02572"
@@ -37837,9 +37837,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02583/assemblies/release2/annotation/cat/HG02583_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63089653,
-    "filename": "HG02583_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02583/assemblies/release2/annotation/cat/HG02583_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111275952,
+    "filename": "HG02583_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02583"
@@ -37990,9 +37990,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02583/assemblies/release2/annotation/cat/HG02583_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63196877,
-    "filename": "HG02583_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02583/assemblies/release2/annotation/cat/HG02583_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111333548,
+    "filename": "HG02583_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02583"
@@ -38143,9 +38143,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02602/assemblies/release2/annotation/cat/HG02602_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63515629,
-    "filename": "HG02602_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02602/assemblies/release2/annotation/cat/HG02602_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112554141,
+    "filename": "HG02602_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02602"
@@ -38296,9 +38296,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02602/assemblies/release2/annotation/cat/HG02602_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61852327,
-    "filename": "HG02602_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02602/assemblies/release2/annotation/cat/HG02602_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 109330021,
+    "filename": "HG02602_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02602"
@@ -38449,9 +38449,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02615/assemblies/release2/annotation/cat/HG02615_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63140179,
-    "filename": "HG02615_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02615/assemblies/release2/annotation/cat/HG02615_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111583591,
+    "filename": "HG02615_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02615"
@@ -38602,9 +38602,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02615/assemblies/release2/annotation/cat/HG02615_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63108984,
-    "filename": "HG02615_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02615/assemblies/release2/annotation/cat/HG02615_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111664888,
+    "filename": "HG02615_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02615"
@@ -38756,7 +38756,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG02622/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02622-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 46290815,
     "filename": "AS-HOR+SF-vs-HG02622-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -38764,9 +38764,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02622/assemblies/release2/annotation/cat/HG02622_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63652928,
-    "filename": "HG02622_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02622/assemblies/release2/annotation/cat/HG02622_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112834543,
+    "filename": "HG02622_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02622"
@@ -39008,7 +39008,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG02622/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02622-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 47435960,
     "filename": "AS-HOR+SF-vs-HG02622-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -39016,9 +39016,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02622/assemblies/release2/annotation/cat/HG02622_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63669289,
-    "filename": "HG02622_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02622/assemblies/release2/annotation/cat/HG02622_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112583808,
+    "filename": "HG02622_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02622"
@@ -39233,7 +39233,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG02630/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02630-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 47718335,
     "filename": "AS-HOR+SF-vs-HG02630-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -39241,9 +39241,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02630/assemblies/release2/annotation/cat/HG02630_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63371207,
-    "filename": "HG02630_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02630/assemblies/release2/annotation/cat/HG02630_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111967905,
+    "filename": "HG02630_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02630"
@@ -39485,7 +39485,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG02630/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02630-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 51708128,
     "filename": "AS-HOR+SF-vs-HG02630-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -39493,9 +39493,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02630/assemblies/release2/annotation/cat/HG02630_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63456893,
-    "filename": "HG02630_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02630/assemblies/release2/annotation/cat/HG02630_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112342794,
+    "filename": "HG02630_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02630"
@@ -39709,9 +39709,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02647/assemblies/release2/annotation/cat/HG02647_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63483677,
-    "filename": "HG02647_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02647/assemblies/release2/annotation/cat/HG02647_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112531877,
+    "filename": "HG02647_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02647"
@@ -39862,9 +39862,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02647/assemblies/release2/annotation/cat/HG02647_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61677723,
-    "filename": "HG02647_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02647/assemblies/release2/annotation/cat/HG02647_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 109340026,
+    "filename": "HG02647_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02647"
@@ -40015,9 +40015,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02668/assemblies/release2/annotation/cat/HG02668_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63258706,
-    "filename": "HG02668_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02668/assemblies/release2/annotation/cat/HG02668_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111436969,
+    "filename": "HG02668_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02668"
@@ -40168,9 +40168,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02668/assemblies/release2/annotation/cat/HG02668_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61734771,
-    "filename": "HG02668_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02668/assemblies/release2/annotation/cat/HG02668_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108376799,
+    "filename": "HG02668_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02668"
@@ -40321,9 +40321,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02698/assemblies/release2/annotation/cat/HG02698_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63415711,
-    "filename": "HG02698_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02698/assemblies/release2/annotation/cat/HG02698_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111780308,
+    "filename": "HG02698_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02698"
@@ -40474,9 +40474,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02698/assemblies/release2/annotation/cat/HG02698_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61567246,
-    "filename": "HG02698_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02698/assemblies/release2/annotation/cat/HG02698_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108606868,
+    "filename": "HG02698_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02698"
@@ -40628,7 +40628,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG02717/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02717-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 48304626,
     "filename": "AS-HOR+SF-vs-HG02717-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -40636,9 +40636,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02717/assemblies/release2/annotation/cat/HG02717_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63562608,
-    "filename": "HG02717_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02717/assemblies/release2/annotation/cat/HG02717_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112277344,
+    "filename": "HG02717_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02717"
@@ -40880,7 +40880,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG02717/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02717-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 48691114,
     "filename": "AS-HOR+SF-vs-HG02717-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -40888,9 +40888,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02717/assemblies/release2/annotation/cat/HG02717_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61834019,
-    "filename": "HG02717_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02717/assemblies/release2/annotation/cat/HG02717_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 109331134,
+    "filename": "HG02717_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02717"
@@ -41105,7 +41105,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02723/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02723-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 45115030,
     "filename": "AS-HOR+SF-vs-HG02723-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -41113,9 +41113,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02723/assemblies/release2/annotation/cat/HG02723_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61666305,
-    "filename": "HG02723_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02723/assemblies/release2/annotation/cat/HG02723_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 104189137,
+    "filename": "HG02723_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02723"
@@ -41357,7 +41357,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02723/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02723-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 49700865,
     "filename": "AS-HOR+SF-vs-HG02723-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -41365,9 +41365,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02723/assemblies/release2/annotation/cat/HG02723_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61655152,
-    "filename": "HG02723_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02723/assemblies/release2/annotation/cat/HG02723_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 104120797,
+    "filename": "HG02723_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02723"
@@ -41581,9 +41581,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02735/assemblies/release2/annotation/cat/HG02735_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63434856,
-    "filename": "HG02735_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02735/assemblies/release2/annotation/cat/HG02735_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111361499,
+    "filename": "HG02735_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02735"
@@ -41734,9 +41734,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02735/assemblies/release2/annotation/cat/HG02735_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61507079,
-    "filename": "HG02735_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02735/assemblies/release2/annotation/cat/HG02735_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 107891483,
+    "filename": "HG02735_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02735"
@@ -41887,9 +41887,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02738/assemblies/release2/annotation/cat/HG02738_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63471555,
-    "filename": "HG02738_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02738/assemblies/release2/annotation/cat/HG02738_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111411520,
+    "filename": "HG02738_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02738"
@@ -42040,9 +42040,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02738/assemblies/release2/annotation/cat/HG02738_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61786449,
-    "filename": "HG02738_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02738/assemblies/release2/annotation/cat/HG02738_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108384376,
+    "filename": "HG02738_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02738"
@@ -42193,9 +42193,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02809/assemblies/release2/annotation/cat/HG02809_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63517842,
-    "filename": "HG02809_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02809/assemblies/release2/annotation/cat/HG02809_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112075743,
+    "filename": "HG02809_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02809"
@@ -42346,9 +42346,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02809/assemblies/release2/annotation/cat/HG02809_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63448811,
-    "filename": "HG02809_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02809/assemblies/release2/annotation/cat/HG02809_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112346497,
+    "filename": "HG02809_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02809"
@@ -42500,7 +42500,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02818/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02818-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 47897466,
     "filename": "AS-HOR+SF-vs-HG02818-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -42508,9 +42508,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02818/assemblies/release2/annotation/cat/HG02818_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61629933,
-    "filename": "HG02818_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02818/assemblies/release2/annotation/cat/HG02818_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 104125156,
+    "filename": "HG02818_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02818"
@@ -42752,7 +42752,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02818/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02818-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 46784311,
     "filename": "AS-HOR+SF-vs-HG02818-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -42760,9 +42760,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02818/assemblies/release2/annotation/cat/HG02818_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61663688,
-    "filename": "HG02818_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG02818/assemblies/release2/annotation/cat/HG02818_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 104089750,
+    "filename": "HG02818_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02818"
@@ -42976,9 +42976,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02841/assemblies/release2/annotation/cat/HG02841_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63248850,
-    "filename": "HG02841_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02841/assemblies/release2/annotation/cat/HG02841_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111499869,
+    "filename": "HG02841_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02841"
@@ -43129,9 +43129,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02841/assemblies/release2/annotation/cat/HG02841_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63372201,
-    "filename": "HG02841_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02841/assemblies/release2/annotation/cat/HG02841_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111724841,
+    "filename": "HG02841_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02841"
@@ -43283,7 +43283,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG02886/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02886-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 45287078,
     "filename": "AS-HOR+SF-vs-HG02886-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -43291,9 +43291,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02886/assemblies/release2/annotation/cat/HG02886_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63732887,
-    "filename": "HG02886_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02886/assemblies/release2/annotation/cat/HG02886_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112657596,
+    "filename": "HG02886_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02886"
@@ -43535,7 +43535,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG02886/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG02886-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 45414020,
     "filename": "AS-HOR+SF-vs-HG02886-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -43543,9 +43543,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02886/assemblies/release2/annotation/cat/HG02886_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63590169,
-    "filename": "HG02886_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02886/assemblies/release2/annotation/cat/HG02886_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112333309,
+    "filename": "HG02886_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02886"
@@ -43759,9 +43759,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02922/assemblies/release2/annotation/cat/HG02922_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63613912,
-    "filename": "HG02922_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02922/assemblies/release2/annotation/cat/HG02922_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112937018,
+    "filename": "HG02922_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02922"
@@ -43912,9 +43912,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02922/assemblies/release2/annotation/cat/HG02922_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63723527,
-    "filename": "HG02922_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02922/assemblies/release2/annotation/cat/HG02922_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 113354135,
+    "filename": "HG02922_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02922"
@@ -44065,9 +44065,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02965/assemblies/release2/annotation/cat/HG02965_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63511173,
-    "filename": "HG02965_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02965/assemblies/release2/annotation/cat/HG02965_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112789810,
+    "filename": "HG02965_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02965"
@@ -44218,9 +44218,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02965/assemblies/release2/annotation/cat/HG02965_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61676457,
-    "filename": "HG02965_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02965/assemblies/release2/annotation/cat/HG02965_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 109467468,
+    "filename": "HG02965_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02965"
@@ -44371,9 +44371,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02976/assemblies/release2/annotation/cat/HG02976_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 64237688,
-    "filename": "HG02976_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02976/assemblies/release2/annotation/cat/HG02976_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 116339121,
+    "filename": "HG02976_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02976"
@@ -44524,9 +44524,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02976/assemblies/release2/annotation/cat/HG02976_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 64292824,
-    "filename": "HG02976_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02976/assemblies/release2/annotation/cat/HG02976_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 116148296,
+    "filename": "HG02976_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02976"
@@ -44677,9 +44677,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02984/assemblies/release2/annotation/cat/HG02984_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63176522,
-    "filename": "HG02984_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02984/assemblies/release2/annotation/cat/HG02984_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111791666,
+    "filename": "HG02984_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG02984"
@@ -44830,9 +44830,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02984/assemblies/release2/annotation/cat/HG02984_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61614080,
-    "filename": "HG02984_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG02984/assemblies/release2/annotation/cat/HG02984_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108890723,
+    "filename": "HG02984_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG02984"
@@ -44983,9 +44983,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03017/assemblies/release2/annotation/cat/HG03017_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63252719,
-    "filename": "HG03017_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03017/assemblies/release2/annotation/cat/HG03017_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111332879,
+    "filename": "HG03017_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03017"
@@ -45136,9 +45136,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03017/assemblies/release2/annotation/cat/HG03017_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61494183,
-    "filename": "HG03017_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03017/assemblies/release2/annotation/cat/HG03017_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 107990511,
+    "filename": "HG03017_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03017"
@@ -45289,9 +45289,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03041/assemblies/release2/annotation/cat/HG03041_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63345117,
-    "filename": "HG03041_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03041/assemblies/release2/annotation/cat/HG03041_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111933513,
+    "filename": "HG03041_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03041"
@@ -45442,9 +45442,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03041/assemblies/release2/annotation/cat/HG03041_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63392646,
-    "filename": "HG03041_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03041/assemblies/release2/annotation/cat/HG03041_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112068991,
+    "filename": "HG03041_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03041"
@@ -45595,9 +45595,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03050/assemblies/release2/annotation/cat/HG03050_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61610691,
-    "filename": "HG03050_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03050/assemblies/release2/annotation/cat/HG03050_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112942703,
+    "filename": "HG03050_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03050"
@@ -45748,9 +45748,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03050/assemblies/release2/annotation/cat/HG03050_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 60095871,
-    "filename": "HG03050_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03050/assemblies/release2/annotation/cat/HG03050_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110454199,
+    "filename": "HG03050_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03050"
@@ -45902,7 +45902,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG03098/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03098-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 49810990,
     "filename": "AS-HOR+SF-vs-HG03098-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -45910,9 +45910,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG03098/assemblies/release2/annotation/cat/HG03098_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61815130,
-    "filename": "HG03098_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG03098/assemblies/release2/annotation/cat/HG03098_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 104189917,
+    "filename": "HG03098_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03098"
@@ -46154,7 +46154,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG03098/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03098-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 45848738,
     "filename": "AS-HOR+SF-vs-HG03098-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -46162,9 +46162,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG03098/assemblies/release2/annotation/cat/HG03098_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 59877579,
-    "filename": "HG03098_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG03098/assemblies/release2/annotation/cat/HG03098_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 101024449,
+    "filename": "HG03098_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03098"
@@ -46378,9 +46378,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03130/assemblies/release2/annotation/cat/HG03130_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63547850,
-    "filename": "HG03130_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03130/assemblies/release2/annotation/cat/HG03130_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112549652,
+    "filename": "HG03130_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03130"
@@ -46531,9 +46531,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03130/assemblies/release2/annotation/cat/HG03130_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61989305,
-    "filename": "HG03130_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03130/assemblies/release2/annotation/cat/HG03130_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 109610009,
+    "filename": "HG03130_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03130"
@@ -46684,9 +46684,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03139/assemblies/release2/annotation/cat/HG03139_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63636184,
-    "filename": "HG03139_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03139/assemblies/release2/annotation/cat/HG03139_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112865321,
+    "filename": "HG03139_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03139"
@@ -46837,9 +46837,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03139/assemblies/release2/annotation/cat/HG03139_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61961416,
-    "filename": "HG03139_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03139/assemblies/release2/annotation/cat/HG03139_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 109934983,
+    "filename": "HG03139_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03139"
@@ -46990,9 +46990,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03195/assemblies/release2/annotation/cat/HG03195_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63544909,
-    "filename": "HG03195_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03195/assemblies/release2/annotation/cat/HG03195_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112473783,
+    "filename": "HG03195_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03195"
@@ -47143,9 +47143,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03195/assemblies/release2/annotation/cat/HG03195_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63542204,
-    "filename": "HG03195_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03195/assemblies/release2/annotation/cat/HG03195_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112378988,
+    "filename": "HG03195_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03195"
@@ -47296,9 +47296,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03209/assemblies/release2/annotation/cat/HG03209_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63425815,
-    "filename": "HG03209_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03209/assemblies/release2/annotation/cat/HG03209_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112256093,
+    "filename": "HG03209_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03209"
@@ -47449,9 +47449,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03209/assemblies/release2/annotation/cat/HG03209_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61672754,
-    "filename": "HG03209_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03209/assemblies/release2/annotation/cat/HG03209_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108918999,
+    "filename": "HG03209_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03209"
@@ -47602,9 +47602,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03225/assemblies/release2/annotation/cat/HG03225_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63867210,
-    "filename": "HG03225_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03225/assemblies/release2/annotation/cat/HG03225_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 114324293,
+    "filename": "HG03225_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03225"
@@ -47755,9 +47755,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03225/assemblies/release2/annotation/cat/HG03225_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 62141684,
-    "filename": "HG03225_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03225/assemblies/release2/annotation/cat/HG03225_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110963979,
+    "filename": "HG03225_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03225"
@@ -47908,9 +47908,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03239/assemblies/release2/annotation/cat/HG03239_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63399749,
-    "filename": "HG03239_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03239/assemblies/release2/annotation/cat/HG03239_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111390376,
+    "filename": "HG03239_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03239"
@@ -48061,9 +48061,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03239/assemblies/release2/annotation/cat/HG03239_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63327467,
-    "filename": "HG03239_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03239/assemblies/release2/annotation/cat/HG03239_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111417576,
+    "filename": "HG03239_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03239"
@@ -48214,9 +48214,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03270/assemblies/release2/annotation/cat/HG03270_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63351564,
-    "filename": "HG03270_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03270/assemblies/release2/annotation/cat/HG03270_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111110065,
+    "filename": "HG03270_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03270"
@@ -48367,9 +48367,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03270/assemblies/release2/annotation/cat/HG03270_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63279670,
-    "filename": "HG03270_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03270/assemblies/release2/annotation/cat/HG03270_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111041608,
+    "filename": "HG03270_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03270"
@@ -48520,9 +48520,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03369/assemblies/release2/annotation/cat/HG03369_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63217679,
-    "filename": "HG03369_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03369/assemblies/release2/annotation/cat/HG03369_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110994998,
+    "filename": "HG03369_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03369"
@@ -48673,9 +48673,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03369/assemblies/release2/annotation/cat/HG03369_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63287246,
-    "filename": "HG03369_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03369/assemblies/release2/annotation/cat/HG03369_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111062520,
+    "filename": "HG03369_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03369"
@@ -48827,7 +48827,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG03453/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03453-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 44914581,
     "filename": "AS-HOR+SF-vs-HG03453-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -48835,9 +48835,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03453/assemblies/release2/annotation/cat/HG03453_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63894915,
-    "filename": "HG03453_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03453/assemblies/release2/annotation/cat/HG03453_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 113171858,
+    "filename": "HG03453_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03453"
@@ -49079,7 +49079,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG03453/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03453-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 50928751,
     "filename": "AS-HOR+SF-vs-HG03453-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -49087,9 +49087,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03453/assemblies/release2/annotation/cat/HG03453_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63937648,
-    "filename": "HG03453_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03453/assemblies/release2/annotation/cat/HG03453_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 113402893,
+    "filename": "HG03453_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03453"
@@ -49303,9 +49303,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03470/assemblies/release2/annotation/cat/HG03470_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63475884,
-    "filename": "HG03470_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03470/assemblies/release2/annotation/cat/HG03470_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112183008,
+    "filename": "HG03470_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03470"
@@ -49456,9 +49456,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03470/assemblies/release2/annotation/cat/HG03470_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63558563,
-    "filename": "HG03470_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03470/assemblies/release2/annotation/cat/HG03470_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112389525,
+    "filename": "HG03470_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03470"
@@ -49609,9 +49609,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03471/assemblies/release2/annotation/cat/HG03471_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61782033,
-    "filename": "HG03471_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03471/assemblies/release2/annotation/cat/HG03471_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 104016825,
+    "filename": "HG03471_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03471"
@@ -49762,9 +49762,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03471/assemblies/release2/annotation/cat/HG03471_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 60193789,
-    "filename": "HG03471_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03471/assemblies/release2/annotation/cat/HG03471_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 101188558,
+    "filename": "HG03471_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03471"
@@ -49916,7 +49916,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG03486/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03486-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 49506362,
     "filename": "AS-HOR+SF-vs-HG03486-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -49924,9 +49924,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG03486/assemblies/release2/annotation/cat/HG03486_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61814609,
-    "filename": "HG03486_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG03486/assemblies/release2/annotation/cat/HG03486_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 104355126,
+    "filename": "HG03486_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03486"
@@ -50168,7 +50168,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG03486/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03486-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 50931608,
     "filename": "AS-HOR+SF-vs-HG03486-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -50176,9 +50176,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG03486/assemblies/release2/annotation/cat/HG03486_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61716237,
-    "filename": "HG03486_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG03486/assemblies/release2/annotation/cat/HG03486_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 104276321,
+    "filename": "HG03486_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03486"
@@ -50393,7 +50393,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG03492/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03492-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 48133232,
     "filename": "AS-HOR+SF-vs-HG03492-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -50492,7 +50492,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/HG03492/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03492-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 45610960,
     "filename": "AS-HOR+SF-vs-HG03492-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -50564,7 +50564,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG03516/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03516-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 43821812,
     "filename": "AS-HOR+SF-vs-HG03516-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -50572,9 +50572,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03516/assemblies/release2/annotation/cat/HG03516_mat_hprc_r2_v1.1.0_cat_v1.1.gff3.gz",
-    "fileSize": 63664802,
-    "filename": "HG03516_mat_hprc_r2_v1.1.0_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03516/assemblies/release2/annotation/cat/HG03516_mat_hprc_r2_v1.1.0_cat_v1.3.gff3.gz",
+    "fileSize": 112701660,
+    "filename": "HG03516_mat_hprc_r2_v1.1.0_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03516"
@@ -50816,7 +50816,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG03516/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03516-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 51832747,
     "filename": "AS-HOR+SF-vs-HG03516-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -50824,9 +50824,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03516/assemblies/release2/annotation/cat/HG03516_pat_hprc_r2_v1.1.0_cat_v1.1.gff3.gz",
-    "fileSize": 63836862,
-    "filename": "HG03516_pat_hprc_r2_v1.1.0_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03516/assemblies/release2/annotation/cat/HG03516_pat_hprc_r2_v1.1.0_cat_v1.3.gff3.gz",
+    "fileSize": 112932271,
+    "filename": "HG03516_pat_hprc_r2_v1.1.0_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03516"
@@ -51040,9 +51040,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03521/assemblies/release2/annotation/cat/HG03521_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63732083,
-    "filename": "HG03521_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03521/assemblies/release2/annotation/cat/HG03521_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111456068,
+    "filename": "HG03521_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03521"
@@ -51193,9 +51193,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03521/assemblies/release2/annotation/cat/HG03521_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61434143,
-    "filename": "HG03521_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03521/assemblies/release2/annotation/cat/HG03521_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 107612954,
+    "filename": "HG03521_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03521"
@@ -51347,7 +51347,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG03540/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03540-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 45096842,
     "filename": "AS-HOR+SF-vs-HG03540-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -51355,9 +51355,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03540/assemblies/release2/annotation/cat/HG03540_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63584852,
-    "filename": "HG03540_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03540/assemblies/release2/annotation/cat/HG03540_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112915500,
+    "filename": "HG03540_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03540"
@@ -51599,7 +51599,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG03540/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03540-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 47758110,
     "filename": "AS-HOR+SF-vs-HG03540-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -51607,9 +51607,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03540/assemblies/release2/annotation/cat/HG03540_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63709318,
-    "filename": "HG03540_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03540/assemblies/release2/annotation/cat/HG03540_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 113145869,
+    "filename": "HG03540_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03540"
@@ -51824,7 +51824,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG03579/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03579-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 45602204,
     "filename": "AS-HOR+SF-vs-HG03579-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -51832,9 +51832,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03579/assemblies/release2/annotation/cat/HG03579_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63269131,
-    "filename": "HG03579_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03579/assemblies/release2/annotation/cat/HG03579_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110742387,
+    "filename": "HG03579_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03579"
@@ -52076,7 +52076,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC/HG03579/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-HG03579-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 44863863,
     "filename": "AS-HOR+SF-vs-HG03579-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -52084,9 +52084,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03579/assemblies/release2/annotation/cat/HG03579_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61386600,
-    "filename": "HG03579_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03579/assemblies/release2/annotation/cat/HG03579_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 107547995,
+    "filename": "HG03579_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03579"
@@ -52300,9 +52300,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03583/assemblies/release2/annotation/cat/HG03583_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63203062,
-    "filename": "HG03583_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03583/assemblies/release2/annotation/cat/HG03583_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111326138,
+    "filename": "HG03583_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03583"
@@ -52453,9 +52453,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03583/assemblies/release2/annotation/cat/HG03583_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63530076,
-    "filename": "HG03583_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03583/assemblies/release2/annotation/cat/HG03583_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111908860,
+    "filename": "HG03583_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03583"
@@ -52606,9 +52606,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03654/assemblies/release2/annotation/cat/HG03654_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63706351,
-    "filename": "HG03654_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03654/assemblies/release2/annotation/cat/HG03654_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112642665,
+    "filename": "HG03654_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03654"
@@ -52759,9 +52759,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03654/assemblies/release2/annotation/cat/HG03654_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61818896,
-    "filename": "HG03654_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03654/assemblies/release2/annotation/cat/HG03654_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 109314013,
+    "filename": "HG03654_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03654"
@@ -52912,9 +52912,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03669/assemblies/release2/annotation/cat/HG03669_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63099864,
-    "filename": "HG03669_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03669/assemblies/release2/annotation/cat/HG03669_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111303046,
+    "filename": "HG03669_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03669"
@@ -53065,9 +53065,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03669/assemblies/release2/annotation/cat/HG03669_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63360051,
-    "filename": "HG03669_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03669/assemblies/release2/annotation/cat/HG03669_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111733806,
+    "filename": "HG03669_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03669"
@@ -53218,9 +53218,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03688/assemblies/release2/annotation/cat/HG03688_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63392860,
-    "filename": "HG03688_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03688/assemblies/release2/annotation/cat/HG03688_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111755246,
+    "filename": "HG03688_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03688"
@@ -53371,9 +53371,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03688/assemblies/release2/annotation/cat/HG03688_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61409584,
-    "filename": "HG03688_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03688/assemblies/release2/annotation/cat/HG03688_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108560005,
+    "filename": "HG03688_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03688"
@@ -53524,9 +53524,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03704/assemblies/release2/annotation/cat/HG03704_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63525667,
-    "filename": "HG03704_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03704/assemblies/release2/annotation/cat/HG03704_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111550763,
+    "filename": "HG03704_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03704"
@@ -53677,9 +53677,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03704/assemblies/release2/annotation/cat/HG03704_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63414042,
-    "filename": "HG03704_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03704/assemblies/release2/annotation/cat/HG03704_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111399475,
+    "filename": "HG03704_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03704"
@@ -53830,9 +53830,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03710/assemblies/release2/annotation/cat/HG03710_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63375501,
-    "filename": "HG03710_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03710/assemblies/release2/annotation/cat/HG03710_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112016320,
+    "filename": "HG03710_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03710"
@@ -53983,9 +53983,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03710/assemblies/release2/annotation/cat/HG03710_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61805207,
-    "filename": "HG03710_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03710/assemblies/release2/annotation/cat/HG03710_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 109177035,
+    "filename": "HG03710_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03710"
@@ -54136,9 +54136,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03742/assemblies/release2/annotation/cat/HG03742_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63431903,
-    "filename": "HG03742_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03742/assemblies/release2/annotation/cat/HG03742_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111604810,
+    "filename": "HG03742_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03742"
@@ -54289,9 +54289,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03742/assemblies/release2/annotation/cat/HG03742_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61700292,
-    "filename": "HG03742_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03742/assemblies/release2/annotation/cat/HG03742_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108758419,
+    "filename": "HG03742_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03742"
@@ -54442,9 +54442,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03784/assemblies/release2/annotation/cat/HG03784_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63288036,
-    "filename": "HG03784_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03784/assemblies/release2/annotation/cat/HG03784_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110949202,
+    "filename": "HG03784_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03784"
@@ -54595,9 +54595,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03784/assemblies/release2/annotation/cat/HG03784_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63290435,
-    "filename": "HG03784_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03784/assemblies/release2/annotation/cat/HG03784_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111104322,
+    "filename": "HG03784_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03784"
@@ -54748,9 +54748,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03804/assemblies/release2/annotation/cat/HG03804_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63489207,
-    "filename": "HG03804_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03804/assemblies/release2/annotation/cat/HG03804_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112171548,
+    "filename": "HG03804_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03804"
@@ -54901,9 +54901,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03804/assemblies/release2/annotation/cat/HG03804_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63505892,
-    "filename": "HG03804_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03804/assemblies/release2/annotation/cat/HG03804_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112216676,
+    "filename": "HG03804_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03804"
@@ -55054,9 +55054,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03816/assemblies/release2/annotation/cat/HG03816_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63345173,
-    "filename": "HG03816_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03816/assemblies/release2/annotation/cat/HG03816_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112063544,
+    "filename": "HG03816_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03816"
@@ -55207,9 +55207,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03816/assemblies/release2/annotation/cat/HG03816_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63409218,
-    "filename": "HG03816_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03816/assemblies/release2/annotation/cat/HG03816_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112069298,
+    "filename": "HG03816_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03816"
@@ -55360,9 +55360,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03831/assemblies/release2/annotation/cat/HG03831_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63486578,
-    "filename": "HG03831_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03831/assemblies/release2/annotation/cat/HG03831_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111870007,
+    "filename": "HG03831_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03831"
@@ -55513,9 +55513,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03831/assemblies/release2/annotation/cat/HG03831_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63578151,
-    "filename": "HG03831_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03831/assemblies/release2/annotation/cat/HG03831_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112206356,
+    "filename": "HG03831_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03831"
@@ -55666,9 +55666,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03834/assemblies/release2/annotation/cat/HG03834_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63433476,
-    "filename": "HG03834_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03834/assemblies/release2/annotation/cat/HG03834_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111116999,
+    "filename": "HG03834_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03834"
@@ -55819,9 +55819,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03834/assemblies/release2/annotation/cat/HG03834_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63422562,
-    "filename": "HG03834_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03834/assemblies/release2/annotation/cat/HG03834_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111097263,
+    "filename": "HG03834_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03834"
@@ -55972,9 +55972,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03874/assemblies/release2/annotation/cat/HG03874_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63487506,
-    "filename": "HG03874_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03874/assemblies/release2/annotation/cat/HG03874_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112223441,
+    "filename": "HG03874_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03874"
@@ -56125,9 +56125,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03874/assemblies/release2/annotation/cat/HG03874_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63641220,
-    "filename": "HG03874_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03874/assemblies/release2/annotation/cat/HG03874_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112463617,
+    "filename": "HG03874_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03874"
@@ -56278,9 +56278,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03927/assemblies/release2/annotation/cat/HG03927_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63532482,
-    "filename": "HG03927_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03927/assemblies/release2/annotation/cat/HG03927_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112627150,
+    "filename": "HG03927_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03927"
@@ -56431,9 +56431,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03927/assemblies/release2/annotation/cat/HG03927_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63435891,
-    "filename": "HG03927_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03927/assemblies/release2/annotation/cat/HG03927_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112563752,
+    "filename": "HG03927_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03927"
@@ -56584,9 +56584,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03942/assemblies/release2/annotation/cat/HG03942_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63110764,
-    "filename": "HG03942_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03942/assemblies/release2/annotation/cat/HG03942_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110042619,
+    "filename": "HG03942_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG03942"
@@ -56737,9 +56737,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03942/assemblies/release2/annotation/cat/HG03942_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61373692,
-    "filename": "HG03942_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG03942/assemblies/release2/annotation/cat/HG03942_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 107167383,
+    "filename": "HG03942_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG03942"
@@ -56890,9 +56890,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG04115/assemblies/release2/annotation/cat/HG04115_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63402647,
-    "filename": "HG04115_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG04115/assemblies/release2/annotation/cat/HG04115_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111736559,
+    "filename": "HG04115_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG04115"
@@ -57043,9 +57043,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG04115/assemblies/release2/annotation/cat/HG04115_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61740721,
-    "filename": "HG04115_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG04115/assemblies/release2/annotation/cat/HG04115_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108721571,
+    "filename": "HG04115_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG04115"
@@ -57196,9 +57196,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG04157/assemblies/release2/annotation/cat/HG04157_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63292100,
-    "filename": "HG04157_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG04157/assemblies/release2/annotation/cat/HG04157_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112052843,
+    "filename": "HG04157_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG04157"
@@ -57349,9 +57349,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG04157/assemblies/release2/annotation/cat/HG04157_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61839132,
-    "filename": "HG04157_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG04157/assemblies/release2/annotation/cat/HG04157_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 109240460,
+    "filename": "HG04157_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG04157"
@@ -57502,9 +57502,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG04160/assemblies/release2/annotation/cat/HG04160_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63591579,
-    "filename": "HG04160_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG04160/assemblies/release2/annotation/cat/HG04160_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112414038,
+    "filename": "HG04160_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG04160"
@@ -57655,9 +57655,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG04160/assemblies/release2/annotation/cat/HG04160_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61706205,
-    "filename": "HG04160_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG04160/assemblies/release2/annotation/cat/HG04160_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 109339701,
+    "filename": "HG04160_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG04160"
@@ -57808,9 +57808,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG04184/assemblies/release2/annotation/cat/HG04184_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61758906,
-    "filename": "HG04184_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG04184/assemblies/release2/annotation/cat/HG04184_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111548353,
+    "filename": "HG04184_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG04184"
@@ -57961,9 +57961,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG04184/assemblies/release2/annotation/cat/HG04184_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61779075,
-    "filename": "HG04184_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG04184/assemblies/release2/annotation/cat/HG04184_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111554165,
+    "filename": "HG04184_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG04184"
@@ -58114,9 +58114,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG04187/assemblies/release2/annotation/cat/HG04187_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63332226,
-    "filename": "HG04187_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG04187/assemblies/release2/annotation/cat/HG04187_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110893182,
+    "filename": "HG04187_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG04187"
@@ -58267,9 +58267,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG04187/assemblies/release2/annotation/cat/HG04187_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61572904,
-    "filename": "HG04187_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG04187/assemblies/release2/annotation/cat/HG04187_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 107718520,
+    "filename": "HG04187_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG04187"
@@ -58420,9 +58420,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG04199/assemblies/release2/annotation/cat/HG04199_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63378943,
-    "filename": "HG04199_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG04199/assemblies/release2/annotation/cat/HG04199_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111757695,
+    "filename": "HG04199_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG04199"
@@ -58573,9 +58573,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG04199/assemblies/release2/annotation/cat/HG04199_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61672428,
-    "filename": "HG04199_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG04199/assemblies/release2/annotation/cat/HG04199_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108697420,
+    "filename": "HG04199_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG04199"
@@ -58726,9 +58726,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG04204/assemblies/release2/annotation/cat/HG04204_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63452438,
-    "filename": "HG04204_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG04204/assemblies/release2/annotation/cat/HG04204_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111456147,
+    "filename": "HG04204_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG04204"
@@ -58879,9 +58879,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG04204/assemblies/release2/annotation/cat/HG04204_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61592527,
-    "filename": "HG04204_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG04204/assemblies/release2/annotation/cat/HG04204_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 107984588,
+    "filename": "HG04204_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG04204"
@@ -59032,9 +59032,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG04228/assemblies/release2/annotation/cat/HG04228_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63144800,
-    "filename": "HG04228_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG04228/assemblies/release2/annotation/cat/HG04228_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111489720,
+    "filename": "HG04228_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG04228"
@@ -59185,9 +59185,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG04228/assemblies/release2/annotation/cat/HG04228_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61631928,
-    "filename": "HG04228_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG04228/assemblies/release2/annotation/cat/HG04228_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108494852,
+    "filename": "HG04228_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG04228"
@@ -59338,9 +59338,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG06807/assemblies/release2/annotation/cat/HG06807_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61070159,
-    "filename": "HG06807_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG06807/assemblies/release2/annotation/cat/HG06807_mat_v1_cat_v1.3.gff3.gz",
+    "fileSize": 104265541,
+    "filename": "HG06807_mat_v1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "HG06807"
@@ -59491,9 +59491,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/HG06807/assemblies/release2/annotation/cat/HG06807_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 60856025,
-    "filename": "HG06807_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/HG06807/assemblies/release2/annotation/cat/HG06807_pat_v1_cat_v1.3.gff3.gz",
+    "fileSize": 103758797,
+    "filename": "HG06807_pat_v1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "HG06807"
@@ -59644,9 +59644,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18505/assemblies/release2/annotation/cat/NA18505_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 64021324,
-    "filename": "NA18505_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18505/assemblies/release2/annotation/cat/NA18505_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 114929007,
+    "filename": "NA18505_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA18505"
@@ -59797,9 +59797,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18505/assemblies/release2/annotation/cat/NA18505_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63932005,
-    "filename": "NA18505_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18505/assemblies/release2/annotation/cat/NA18505_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 114448514,
+    "filename": "NA18505_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA18505"
@@ -59950,9 +59950,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18508/assemblies/release2/annotation/cat/NA18508_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63595303,
-    "filename": "NA18508_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18508/assemblies/release2/annotation/cat/NA18508_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112664603,
+    "filename": "NA18508_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA18508"
@@ -60103,9 +60103,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18508/assemblies/release2/annotation/cat/NA18508_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63201026,
-    "filename": "NA18508_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18508/assemblies/release2/annotation/cat/NA18508_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111705842,
+    "filename": "NA18508_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA18508"
@@ -60256,9 +60256,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18522/assemblies/release2/annotation/cat/NA18522_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63746643,
-    "filename": "NA18522_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18522/assemblies/release2/annotation/cat/NA18522_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 113236508,
+    "filename": "NA18522_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA18522"
@@ -60409,9 +60409,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18522/assemblies/release2/annotation/cat/NA18522_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 62126694,
-    "filename": "NA18522_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18522/assemblies/release2/annotation/cat/NA18522_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110553725,
+    "filename": "NA18522_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA18522"
@@ -60562,9 +60562,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18565/assemblies/release2/annotation/cat/NA18565_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63278520,
-    "filename": "NA18565_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18565/assemblies/release2/annotation/cat/NA18565_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110738448,
+    "filename": "NA18565_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA18565"
@@ -60715,9 +60715,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18565/assemblies/release2/annotation/cat/NA18565_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63161912,
-    "filename": "NA18565_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18565/assemblies/release2/annotation/cat/NA18565_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110568730,
+    "filename": "NA18565_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA18565"
@@ -60868,9 +60868,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18570/assemblies/release2/annotation/cat/NA18570_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63395747,
-    "filename": "NA18570_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18570/assemblies/release2/annotation/cat/NA18570_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111960114,
+    "filename": "NA18570_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA18570"
@@ -61021,9 +61021,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18570/assemblies/release2/annotation/cat/NA18570_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63456011,
-    "filename": "NA18570_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18570/assemblies/release2/annotation/cat/NA18570_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111956692,
+    "filename": "NA18570_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA18570"
@@ -61174,9 +61174,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18608/assemblies/release2/annotation/cat/NA18608_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63436468,
-    "filename": "NA18608_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18608/assemblies/release2/annotation/cat/NA18608_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111491830,
+    "filename": "NA18608_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA18608"
@@ -61327,9 +61327,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18608/assemblies/release2/annotation/cat/NA18608_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 62038129,
-    "filename": "NA18608_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18608/assemblies/release2/annotation/cat/NA18608_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108874093,
+    "filename": "NA18608_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA18608"
@@ -61480,9 +61480,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18620/assemblies/release2/annotation/cat/NA18620_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63730026,
-    "filename": "NA18620_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18620/assemblies/release2/annotation/cat/NA18620_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112270917,
+    "filename": "NA18620_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA18620"
@@ -61633,9 +61633,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18620/assemblies/release2/annotation/cat/NA18620_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61872141,
-    "filename": "NA18620_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18620/assemblies/release2/annotation/cat/NA18620_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 109074173,
+    "filename": "NA18620_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA18620"
@@ -61786,9 +61786,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18747/assemblies/release2/annotation/cat/NA18747_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63215798,
-    "filename": "NA18747_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18747/assemblies/release2/annotation/cat/NA18747_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 103078173,
+    "filename": "NA18747_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA18747"
@@ -61939,9 +61939,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18747/assemblies/release2/annotation/cat/NA18747_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61202974,
-    "filename": "NA18747_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18747/assemblies/release2/annotation/cat/NA18747_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 106994007,
+    "filename": "NA18747_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA18747"
@@ -62092,9 +62092,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18879/assemblies/release2/annotation/cat/NA18879_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63342467,
-    "filename": "NA18879_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18879/assemblies/release2/annotation/cat/NA18879_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111122947,
+    "filename": "NA18879_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA18879"
@@ -62245,9 +62245,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18879/assemblies/release2/annotation/cat/NA18879_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61451365,
-    "filename": "NA18879_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18879/assemblies/release2/annotation/cat/NA18879_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 107865214,
+    "filename": "NA18879_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA18879"
@@ -62399,7 +62399,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/NA18906/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-NA18906-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 46958226,
     "filename": "AS-HOR+SF-vs-NA18906-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -62407,9 +62407,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/NA18906/assemblies/release2/annotation/cat/NA18906_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61718797,
-    "filename": "NA18906_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/NA18906/assemblies/release2/annotation/cat/NA18906_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 104046408,
+    "filename": "NA18906_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA18906"
@@ -62651,7 +62651,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/NA18906/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-NA18906-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 44237834,
     "filename": "AS-HOR+SF-vs-NA18906-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -62659,9 +62659,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/NA18906/assemblies/release2/annotation/cat/NA18906_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61826973,
-    "filename": "NA18906_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/NA18906/assemblies/release2/annotation/cat/NA18906_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 104402853,
+    "filename": "NA18906_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA18906"
@@ -62875,9 +62875,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPP/NA18940/assemblies/release2/annotation/cat/NA18940_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 60620202,
-    "filename": "NA18940_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPP/NA18940/assemblies/release2/annotation/cat/NA18940_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 103481518,
+    "filename": "NA18940_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA18940"
@@ -63028,9 +63028,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPP/NA18940/assemblies/release2/annotation/cat/NA18940_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 59816005,
-    "filename": "NA18940_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPP/NA18940/assemblies/release2/annotation/cat/NA18940_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 100702586,
+    "filename": "NA18940_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA18940"
@@ -63181,9 +63181,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPP/NA18943/assemblies/release2/annotation/cat/NA18943_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61747545,
-    "filename": "NA18943_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPP/NA18943/assemblies/release2/annotation/cat/NA18943_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 104025609,
+    "filename": "NA18943_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA18943"
@@ -63334,9 +63334,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPP/NA18943/assemblies/release2/annotation/cat/NA18943_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 60196480,
-    "filename": "NA18943_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPP/NA18943/assemblies/release2/annotation/cat/NA18943_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 101062234,
+    "filename": "NA18943_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA18943"
@@ -63487,9 +63487,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPP/NA18944/assemblies/release2/annotation/cat/NA18944_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61644253,
-    "filename": "NA18944_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPP/NA18944/assemblies/release2/annotation/cat/NA18944_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 103918195,
+    "filename": "NA18944_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA18944"
@@ -63640,9 +63640,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPP/NA18944/assemblies/release2/annotation/cat/NA18944_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 60122199,
-    "filename": "NA18944_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPP/NA18944/assemblies/release2/annotation/cat/NA18944_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 101091440,
+    "filename": "NA18944_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA18944"
@@ -63793,9 +63793,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPP/NA18945/assemblies/release2/annotation/cat/NA18945_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61717412,
-    "filename": "NA18945_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPP/NA18945/assemblies/release2/annotation/cat/NA18945_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 103918709,
+    "filename": "NA18945_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA18945"
@@ -63946,9 +63946,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPP/NA18945/assemblies/release2/annotation/cat/NA18945_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 59969198,
-    "filename": "NA18945_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPP/NA18945/assemblies/release2/annotation/cat/NA18945_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 99611882,
+    "filename": "NA18945_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA18945"
@@ -64099,9 +64099,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPP/NA18948/assemblies/release2/annotation/cat/NA18948_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61185054,
-    "filename": "NA18948_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPP/NA18948/assemblies/release2/annotation/cat/NA18948_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 104132831,
+    "filename": "NA18948_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA18948"
@@ -64252,9 +64252,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPP/NA18948/assemblies/release2/annotation/cat/NA18948_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 60093160,
-    "filename": "NA18948_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPP/NA18948/assemblies/release2/annotation/cat/NA18948_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 101019430,
+    "filename": "NA18948_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA18948"
@@ -64405,9 +64405,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18952/assemblies/release2/annotation/cat/NA18952_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63451854,
-    "filename": "NA18952_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18952/assemblies/release2/annotation/cat/NA18952_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111515457,
+    "filename": "NA18952_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA18952"
@@ -64558,9 +64558,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18952/assemblies/release2/annotation/cat/NA18952_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61805970,
-    "filename": "NA18952_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18952/assemblies/release2/annotation/cat/NA18952_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108539839,
+    "filename": "NA18952_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA18952"
@@ -64711,9 +64711,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPP/NA18959/assemblies/release2/annotation/cat/NA18959_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61956850,
-    "filename": "NA18959_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPP/NA18959/assemblies/release2/annotation/cat/NA18959_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 104330358,
+    "filename": "NA18959_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA18959"
@@ -64864,9 +64864,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPP/NA18959/assemblies/release2/annotation/cat/NA18959_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 59962282,
-    "filename": "NA18959_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPP/NA18959/assemblies/release2/annotation/cat/NA18959_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 100939505,
+    "filename": "NA18959_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA18959"
@@ -65017,9 +65017,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPP/NA18960/assemblies/release2/annotation/cat/NA18960_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61744809,
-    "filename": "NA18960_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPP/NA18960/assemblies/release2/annotation/cat/NA18960_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 103890316,
+    "filename": "NA18960_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA18960"
@@ -65170,9 +65170,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPP/NA18960/assemblies/release2/annotation/cat/NA18960_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 60158802,
-    "filename": "NA18960_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPP/NA18960/assemblies/release2/annotation/cat/NA18960_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 101157294,
+    "filename": "NA18960_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA18960"
@@ -65323,9 +65323,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPP/NA18967/assemblies/release2/annotation/cat/NA18967_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63122804,
-    "filename": "NA18967_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPP/NA18967/assemblies/release2/annotation/cat/NA18967_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110431369,
+    "filename": "NA18967_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA18967"
@@ -65476,9 +65476,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPP/NA18967/assemblies/release2/annotation/cat/NA18967_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61903743,
-    "filename": "NA18967_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPP/NA18967/assemblies/release2/annotation/cat/NA18967_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108110620,
+    "filename": "NA18967_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA18967"
@@ -65629,9 +65629,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPP/NA18970/assemblies/release2/annotation/cat/NA18970_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63534793,
-    "filename": "NA18970_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPP/NA18970/assemblies/release2/annotation/cat/NA18970_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111715769,
+    "filename": "NA18970_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA18970"
@@ -65782,9 +65782,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPP/NA18970/assemblies/release2/annotation/cat/NA18970_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61494294,
-    "filename": "NA18970_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPP/NA18970/assemblies/release2/annotation/cat/NA18970_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 107980844,
+    "filename": "NA18970_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA18970"
@@ -65935,9 +65935,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18971/assemblies/release2/annotation/cat/NA18971_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63120773,
-    "filename": "NA18971_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18971/assemblies/release2/annotation/cat/NA18971_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110654906,
+    "filename": "NA18971_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA18971"
@@ -66088,9 +66088,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18971/assemblies/release2/annotation/cat/NA18971_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61564122,
-    "filename": "NA18971_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18971/assemblies/release2/annotation/cat/NA18971_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 107882733,
+    "filename": "NA18971_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA18971"
@@ -66241,9 +66241,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18974/assemblies/release2/annotation/cat/NA18974_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63593638,
-    "filename": "NA18974_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18974/assemblies/release2/annotation/cat/NA18974_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111454734,
+    "filename": "NA18974_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA18974"
@@ -66394,9 +66394,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18974/assemblies/release2/annotation/cat/NA18974_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61857384,
-    "filename": "NA18974_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18974/assemblies/release2/annotation/cat/NA18974_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108474680,
+    "filename": "NA18974_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA18974"
@@ -66547,9 +66547,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18976/assemblies/release2/annotation/cat/NA18976_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63278870,
-    "filename": "NA18976_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18976/assemblies/release2/annotation/cat/NA18976_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110833061,
+    "filename": "NA18976_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA18976"
@@ -66700,9 +66700,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18976/assemblies/release2/annotation/cat/NA18976_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63301390,
-    "filename": "NA18976_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18976/assemblies/release2/annotation/cat/NA18976_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110742336,
+    "filename": "NA18976_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA18976"
@@ -66853,9 +66853,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPP/NA18982/assemblies/release2/annotation/cat/NA18982_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 60855520,
-    "filename": "NA18982_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPP/NA18982/assemblies/release2/annotation/cat/NA18982_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 103803539,
+    "filename": "NA18982_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA18982"
@@ -67006,9 +67006,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPP/NA18982/assemblies/release2/annotation/cat/NA18982_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 60013701,
-    "filename": "NA18982_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPP/NA18982/assemblies/release2/annotation/cat/NA18982_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 100926554,
+    "filename": "NA18982_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA18982"
@@ -67159,9 +67159,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18983/assemblies/release2/annotation/cat/NA18983_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63350292,
-    "filename": "NA18983_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18983/assemblies/release2/annotation/cat/NA18983_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110942088,
+    "filename": "NA18983_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA18983"
@@ -67312,9 +67312,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18983/assemblies/release2/annotation/cat/NA18983_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61547271,
-    "filename": "NA18983_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA18983/assemblies/release2/annotation/cat/NA18983_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 107604616,
+    "filename": "NA18983_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA18983"
@@ -67465,9 +67465,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19036/assemblies/release2/annotation/cat/NA19036_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63251303,
-    "filename": "NA19036_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19036/assemblies/release2/annotation/cat/NA19036_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111550180,
+    "filename": "NA19036_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA19036"
@@ -67618,9 +67618,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19036/assemblies/release2/annotation/cat/NA19036_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63110428,
-    "filename": "NA19036_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19036/assemblies/release2/annotation/cat/NA19036_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111278794,
+    "filename": "NA19036_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA19036"
@@ -67771,9 +67771,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19043/assemblies/release2/annotation/cat/NA19043_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63542093,
-    "filename": "NA19043_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19043/assemblies/release2/annotation/cat/NA19043_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111996125,
+    "filename": "NA19043_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA19043"
@@ -67924,9 +67924,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19043/assemblies/release2/annotation/cat/NA19043_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61768908,
-    "filename": "NA19043_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19043/assemblies/release2/annotation/cat/NA19043_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108791696,
+    "filename": "NA19043_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA19043"
@@ -68077,9 +68077,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19087/assemblies/release2/annotation/cat/NA19087_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 62758358,
-    "filename": "NA19087_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19087/assemblies/release2/annotation/cat/NA19087_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112193030,
+    "filename": "NA19087_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA19087"
@@ -68230,9 +68230,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19087/assemblies/release2/annotation/cat/NA19087_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63647871,
-    "filename": "NA19087_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19087/assemblies/release2/annotation/cat/NA19087_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112694824,
+    "filename": "NA19087_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA19087"
@@ -68383,9 +68383,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19159/assemblies/release2/annotation/cat/NA19159_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63299656,
-    "filename": "NA19159_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19159/assemblies/release2/annotation/cat/NA19159_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111934494,
+    "filename": "NA19159_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA19159"
@@ -68536,9 +68536,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19159/assemblies/release2/annotation/cat/NA19159_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61590507,
-    "filename": "NA19159_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19159/assemblies/release2/annotation/cat/NA19159_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112069842,
+    "filename": "NA19159_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA19159"
@@ -68689,9 +68689,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19185/assemblies/release2/annotation/cat/NA19185_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63397040,
-    "filename": "NA19185_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19185/assemblies/release2/annotation/cat/NA19185_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112735861,
+    "filename": "NA19185_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA19185"
@@ -68842,9 +68842,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19185/assemblies/release2/annotation/cat/NA19185_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63295466,
-    "filename": "NA19185_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19185/assemblies/release2/annotation/cat/NA19185_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112799141,
+    "filename": "NA19185_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA19185"
@@ -68996,7 +68996,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/NA19240/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-NA19240-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 45716532,
     "filename": "AS-HOR+SF-vs-NA19240-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -69004,9 +69004,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/NA19240/assemblies/release2/annotation/cat/NA19240_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61632708,
-    "filename": "NA19240_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/NA19240/assemblies/release2/annotation/cat/NA19240_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 104164399,
+    "filename": "NA19240_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA19240"
@@ -69230,7 +69230,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/NA19240/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-NA19240-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 45236400,
     "filename": "AS-HOR+SF-vs-NA19240-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -69238,9 +69238,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/NA19240/assemblies/release2/annotation/cat/NA19240_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61656123,
-    "filename": "NA19240_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/NA19240/assemblies/release2/annotation/cat/NA19240_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 104125921,
+    "filename": "NA19240_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA19240"
@@ -69436,9 +69436,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19338/assemblies/release2/annotation/cat/NA19338_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 62870895,
-    "filename": "NA19338_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19338/assemblies/release2/annotation/cat/NA19338_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 113742505,
+    "filename": "NA19338_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA19338"
@@ -69589,9 +69589,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19338/assemblies/release2/annotation/cat/NA19338_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63687421,
-    "filename": "NA19338_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19338/assemblies/release2/annotation/cat/NA19338_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 113593730,
+    "filename": "NA19338_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA19338"
@@ -69742,9 +69742,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19391/assemblies/release2/annotation/cat/NA19391_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63501169,
-    "filename": "NA19391_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19391/assemblies/release2/annotation/cat/NA19391_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111837346,
+    "filename": "NA19391_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA19391"
@@ -69895,9 +69895,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19391/assemblies/release2/annotation/cat/NA19391_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63650432,
-    "filename": "NA19391_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19391/assemblies/release2/annotation/cat/NA19391_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112339093,
+    "filename": "NA19391_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA19391"
@@ -70048,9 +70048,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19443/assemblies/release2/annotation/cat/NA19443_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63303186,
-    "filename": "NA19443_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19443/assemblies/release2/annotation/cat/NA19443_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111282384,
+    "filename": "NA19443_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA19443"
@@ -70201,9 +70201,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19443/assemblies/release2/annotation/cat/NA19443_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61695150,
-    "filename": "NA19443_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19443/assemblies/release2/annotation/cat/NA19443_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108560847,
+    "filename": "NA19443_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA19443"
@@ -70354,9 +70354,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19468/assemblies/release2/annotation/cat/NA19468_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 62624222,
-    "filename": "NA19468_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19468/assemblies/release2/annotation/cat/NA19468_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111952902,
+    "filename": "NA19468_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA19468"
@@ -70507,9 +70507,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19468/assemblies/release2/annotation/cat/NA19468_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63267384,
-    "filename": "NA19468_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19468/assemblies/release2/annotation/cat/NA19468_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111588192,
+    "filename": "NA19468_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA19468"
@@ -70660,9 +70660,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19682/assemblies/release2/annotation/cat/NA19682_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63484142,
-    "filename": "NA19682_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19682/assemblies/release2/annotation/cat/NA19682_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111351060,
+    "filename": "NA19682_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA19682"
@@ -70813,9 +70813,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19682/assemblies/release2/annotation/cat/NA19682_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61442555,
-    "filename": "NA19682_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19682/assemblies/release2/annotation/cat/NA19682_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 107961194,
+    "filename": "NA19682_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA19682"
@@ -70966,9 +70966,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19700/assemblies/release2/annotation/cat/NA19700_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63483121,
-    "filename": "NA19700_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19700/assemblies/release2/annotation/cat/NA19700_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111990037,
+    "filename": "NA19700_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA19700"
@@ -71119,9 +71119,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19700/assemblies/release2/annotation/cat/NA19700_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61954528,
-    "filename": "NA19700_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19700/assemblies/release2/annotation/cat/NA19700_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 109031750,
+    "filename": "NA19700_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA19700"
@@ -71272,9 +71272,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19776/assemblies/release2/annotation/cat/NA19776_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63299425,
-    "filename": "NA19776_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19776/assemblies/release2/annotation/cat/NA19776_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111201052,
+    "filename": "NA19776_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA19776"
@@ -71425,9 +71425,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19776/assemblies/release2/annotation/cat/NA19776_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63211890,
-    "filename": "NA19776_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19776/assemblies/release2/annotation/cat/NA19776_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111125823,
+    "filename": "NA19776_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA19776"
@@ -71578,9 +71578,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19835/assemblies/release2/annotation/cat/NA19835_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63487478,
-    "filename": "NA19835_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19835/assemblies/release2/annotation/cat/NA19835_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111038310,
+    "filename": "NA19835_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA19835"
@@ -71731,9 +71731,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19835/assemblies/release2/annotation/cat/NA19835_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63278054,
-    "filename": "NA19835_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19835/assemblies/release2/annotation/cat/NA19835_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110670993,
+    "filename": "NA19835_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA19835"
@@ -71884,9 +71884,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19909/assemblies/release2/annotation/cat/NA19909_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63267088,
-    "filename": "NA19909_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19909/assemblies/release2/annotation/cat/NA19909_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110810198,
+    "filename": "NA19909_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA19909"
@@ -72037,9 +72037,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19909/assemblies/release2/annotation/cat/NA19909_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63223026,
-    "filename": "NA19909_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA19909/assemblies/release2/annotation/cat/NA19909_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110833042,
+    "filename": "NA19909_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA19909"
@@ -72191,7 +72191,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/NA20129/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-NA20129-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 46593286,
     "filename": "AS-HOR+SF-vs-NA20129-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -72199,9 +72199,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/NA20129/assemblies/release2/annotation/cat/NA20129_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61638409,
-    "filename": "NA20129_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/NA20129/assemblies/release2/annotation/cat/NA20129_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 103967740,
+    "filename": "NA20129_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA20129"
@@ -72443,7 +72443,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/NA20129/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-NA20129-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 46467558,
     "filename": "AS-HOR+SF-vs-NA20129-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -72451,9 +72451,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/NA20129/assemblies/release2/annotation/cat/NA20129_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61714152,
-    "filename": "NA20129_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/NA20129/assemblies/release2/annotation/cat/NA20129_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 104202813,
+    "filename": "NA20129_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA20129"
@@ -72667,9 +72667,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20282/assemblies/release2/annotation/cat/NA20282_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 62909570,
-    "filename": "NA20282_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20282/assemblies/release2/annotation/cat/NA20282_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 109304505,
+    "filename": "NA20282_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA20282"
@@ -72820,9 +72820,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20282/assemblies/release2/annotation/cat/NA20282_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63271704,
-    "filename": "NA20282_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20282/assemblies/release2/annotation/cat/NA20282_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 109761381,
+    "filename": "NA20282_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA20282"
@@ -72973,9 +72973,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20346/assemblies/release2/annotation/cat/NA20346_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63434175,
-    "filename": "NA20346_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20346/assemblies/release2/annotation/cat/NA20346_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111155045,
+    "filename": "NA20346_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA20346"
@@ -73126,9 +73126,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20346/assemblies/release2/annotation/cat/NA20346_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61737082,
-    "filename": "NA20346_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20346/assemblies/release2/annotation/cat/NA20346_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108155123,
+    "filename": "NA20346_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA20346"
@@ -73279,9 +73279,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20503/assemblies/release2/annotation/cat/NA20503_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63142336,
-    "filename": "NA20503_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20503/assemblies/release2/annotation/cat/NA20503_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110537012,
+    "filename": "NA20503_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA20503"
@@ -73432,9 +73432,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20503/assemblies/release2/annotation/cat/NA20503_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63058446,
-    "filename": "NA20503_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20503/assemblies/release2/annotation/cat/NA20503_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110311174,
+    "filename": "NA20503_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA20503"
@@ -73585,9 +73585,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20752/assemblies/release2/annotation/cat/NA20752_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63570013,
-    "filename": "NA20752_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20752/assemblies/release2/annotation/cat/NA20752_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111843874,
+    "filename": "NA20752_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA20752"
@@ -73738,9 +73738,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20752/assemblies/release2/annotation/cat/NA20752_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61832191,
-    "filename": "NA20752_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20752/assemblies/release2/annotation/cat/NA20752_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108777313,
+    "filename": "NA20752_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA20752"
@@ -73891,9 +73891,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20762/assemblies/release2/annotation/cat/NA20762_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63252494,
-    "filename": "NA20762_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20762/assemblies/release2/annotation/cat/NA20762_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111409723,
+    "filename": "NA20762_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA20762"
@@ -74044,9 +74044,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20762/assemblies/release2/annotation/cat/NA20762_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 60853437,
-    "filename": "NA20762_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20762/assemblies/release2/annotation/cat/NA20762_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 107151480,
+    "filename": "NA20762_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA20762"
@@ -74197,9 +74197,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20799/assemblies/release2/annotation/cat/NA20799_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63351230,
-    "filename": "NA20799_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20799/assemblies/release2/annotation/cat/NA20799_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111598176,
+    "filename": "NA20799_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA20799"
@@ -74350,9 +74350,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20799/assemblies/release2/annotation/cat/NA20799_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63673603,
-    "filename": "NA20799_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20799/assemblies/release2/annotation/cat/NA20799_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112012722,
+    "filename": "NA20799_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA20799"
@@ -74503,9 +74503,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20805/assemblies/release2/annotation/cat/NA20805_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63501629,
-    "filename": "NA20805_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20805/assemblies/release2/annotation/cat/NA20805_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111286654,
+    "filename": "NA20805_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA20805"
@@ -74656,9 +74656,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20805/assemblies/release2/annotation/cat/NA20805_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61386576,
-    "filename": "NA20805_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20805/assemblies/release2/annotation/cat/NA20805_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 107755386,
+    "filename": "NA20805_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA20805"
@@ -74809,9 +74809,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20806/assemblies/release2/annotation/cat/NA20806_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63333317,
-    "filename": "NA20806_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20806/assemblies/release2/annotation/cat/NA20806_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110997767,
+    "filename": "NA20806_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA20806"
@@ -74962,9 +74962,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20806/assemblies/release2/annotation/cat/NA20806_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61494055,
-    "filename": "NA20806_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20806/assemblies/release2/annotation/cat/NA20806_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 107612933,
+    "filename": "NA20806_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA20806"
@@ -75115,9 +75115,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20809/assemblies/release2/annotation/cat/NA20809_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63227987,
-    "filename": "NA20809_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20809/assemblies/release2/annotation/cat/NA20809_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110109634,
+    "filename": "NA20809_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA20809"
@@ -75268,9 +75268,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20809/assemblies/release2/annotation/cat/NA20809_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61707624,
-    "filename": "NA20809_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20809/assemblies/release2/annotation/cat/NA20809_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 107386626,
+    "filename": "NA20809_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA20809"
@@ -75421,9 +75421,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20827/assemblies/release2/annotation/cat/NA20827_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 62369841,
-    "filename": "NA20827_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20827/assemblies/release2/annotation/cat/NA20827_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110718586,
+    "filename": "NA20827_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA20827"
@@ -75574,9 +75574,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20827/assemblies/release2/annotation/cat/NA20827_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61298076,
-    "filename": "NA20827_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20827/assemblies/release2/annotation/cat/NA20827_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 107564429,
+    "filename": "NA20827_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA20827"
@@ -75727,9 +75727,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20850/assemblies/release2/annotation/cat/NA20850_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63218750,
-    "filename": "NA20850_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20850/assemblies/release2/annotation/cat/NA20850_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110863774,
+    "filename": "NA20850_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA20850"
@@ -75880,9 +75880,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20850/assemblies/release2/annotation/cat/NA20850_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61477806,
-    "filename": "NA20850_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20850/assemblies/release2/annotation/cat/NA20850_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 107859674,
+    "filename": "NA20850_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA20850"
@@ -76033,9 +76033,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20870/assemblies/release2/annotation/cat/NA20870_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63771404,
-    "filename": "NA20870_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20870/assemblies/release2/annotation/cat/NA20870_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112134182,
+    "filename": "NA20870_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA20870"
@@ -76186,9 +76186,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20870/assemblies/release2/annotation/cat/NA20870_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61703736,
-    "filename": "NA20870_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20870/assemblies/release2/annotation/cat/NA20870_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108557506,
+    "filename": "NA20870_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA20870"
@@ -76339,9 +76339,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20905/assemblies/release2/annotation/cat/NA20905_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63561731,
-    "filename": "NA20905_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20905/assemblies/release2/annotation/cat/NA20905_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112247802,
+    "filename": "NA20905_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA20905"
@@ -76492,9 +76492,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20905/assemblies/release2/annotation/cat/NA20905_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61802599,
-    "filename": "NA20905_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA20905/assemblies/release2/annotation/cat/NA20905_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 109068047,
+    "filename": "NA20905_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA20905"
@@ -76645,9 +76645,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA21093/assemblies/release2/annotation/cat/NA21093_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63454983,
-    "filename": "NA21093_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA21093/assemblies/release2/annotation/cat/NA21093_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111682759,
+    "filename": "NA21093_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA21093"
@@ -76798,9 +76798,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA21093/assemblies/release2/annotation/cat/NA21093_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61611613,
-    "filename": "NA21093_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA21093/assemblies/release2/annotation/cat/NA21093_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 108515359,
+    "filename": "NA21093_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA21093"
@@ -76951,9 +76951,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA21102/assemblies/release2/annotation/cat/NA21102_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63219005,
-    "filename": "NA21102_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA21102/assemblies/release2/annotation/cat/NA21102_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110131670,
+    "filename": "NA21102_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA21102"
@@ -77104,9 +77104,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA21102/assemblies/release2/annotation/cat/NA21102_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63171610,
-    "filename": "NA21102_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA21102/assemblies/release2/annotation/cat/NA21102_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110008499,
+    "filename": "NA21102_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA21102"
@@ -77257,9 +77257,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA21106/assemblies/release2/annotation/cat/NA21106_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63801433,
-    "filename": "NA21106_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA21106/assemblies/release2/annotation/cat/NA21106_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 113311206,
+    "filename": "NA21106_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA21106"
@@ -77410,9 +77410,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA21106/assemblies/release2/annotation/cat/NA21106_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63689514,
-    "filename": "NA21106_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA21106/assemblies/release2/annotation/cat/NA21106_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 113409741,
+    "filename": "NA21106_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA21106"
@@ -77563,9 +77563,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA21110/assemblies/release2/annotation/cat/NA21110_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63637489,
-    "filename": "NA21110_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA21110/assemblies/release2/annotation/cat/NA21110_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111056327,
+    "filename": "NA21110_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA21110"
@@ -77716,9 +77716,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA21110/assemblies/release2/annotation/cat/NA21110_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63692680,
-    "filename": "NA21110_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA21110/assemblies/release2/annotation/cat/NA21110_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 112664430,
+    "filename": "NA21110_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA21110"
@@ -77869,9 +77869,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA21144/assemblies/release2/annotation/cat/NA21144_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63229738,
-    "filename": "NA21144_hap2_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA21144/assemblies/release2/annotation/cat/NA21144_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 110960010,
+    "filename": "NA21144_hap2_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA21144"
@@ -78022,9 +78022,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC/NA21144/assemblies/release2/annotation/cat/NA21144_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 63330264,
-    "filename": "NA21144_hap1_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC/NA21144/assemblies/release2/annotation/cat/NA21144_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 111013122,
+    "filename": "NA21144_hap1_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA21144"
@@ -78176,7 +78176,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/NA21309/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-NA21309-maternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 43547705,
     "filename": "AS-HOR+SF-vs-NA21309-maternal.bed",
     "haplotype": "maternal",
     "release": "1",
@@ -78184,9 +78184,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/NA21309/assemblies/release2/annotation/cat/NA21309_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61762037,
-    "filename": "NA21309_mat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/NA21309/assemblies/release2/annotation/cat/NA21309_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 104132495,
+    "filename": "NA21309_mat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "maternal",
     "release": "2",
     "sampleId": "NA21309"
@@ -78428,7 +78428,7 @@
   {
     "annotationType": "ASat",
     "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/NA21309/assemblies/year1_f1_assembly_v2_genbank/annotation/asat/AS-HOR+SF-vs-NA21309-paternal.bed",
-    "fileSize": "N/A",
+    "fileSize": 44926696,
     "filename": "AS-HOR+SF-vs-NA21309-paternal.bed",
     "haplotype": "paternal",
     "release": "1",
@@ -78436,9 +78436,9 @@
   },
   {
     "annotationType": "CAT Genes",
-    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/NA21309/assemblies/release2/annotation/cat/NA21309_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
-    "fileSize": 61809083,
-    "filename": "NA21309_pat_hprc_r2_v1.0.1_cat_v1.1.gff3.gz",
+    "fileLocation": "s3://human-pangenomics/working/HPRC_PLUS/NA21309/assemblies/release2/annotation/cat/NA21309_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
+    "fileSize": 104149452,
+    "filename": "NA21309_pat_hprc_r2_v1.0.1_cat_v1.3.gff3.gz",
     "haplotype": "paternal",
     "release": "2",
     "sampleId": "NA21309"


### PR DESCRIPTION
Closes #211

Looks like the alignments CSV was updated in the repository but never built from, so that's showing up here as well