### PR TITLE
feat: default release filter for assemblies and annotations #223

### DIFF
--- a/e2e/hprc-default-filters.spec.ts
+++ b/e2e/hprc-default-filters.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "@playwright/test";
+
+const DEFAULT_RELEASE_FILTER = [
+  {
+    categoryKey: "release",
+    value: ["2"],
+  },
+];
+
+for (const route of ["/assemblies", "/annotations"]) {
+  test(`Expect ${route} to apply the default Release 2 filter on initial load`, async ({
+    page,
+  }) => {
+    await page.goto(route);
+    await page.waitForURL(/filter=/);
+
+    const filterParam = new URL(page.url()).searchParams.get("filter");
+
+    expect(filterParam).not.toBeNull();
+    expect(JSON.parse(filterParam as string)).toEqual(DEFAULT_RELEASE_FILTER);
+    await expect(page.getByText(/^Results 1 - \d+ of \d+/)).toBeVisible();
+  });
+}
+
+test("Expect the default Release 2 filter on /assemblies to stay cleared after user removes it", async ({
+  page,
+}) => {
+  await page.goto("/assemblies");
+  await page.waitForURL(/filter=/);
+
+  await page.getByText(/^Release\s+\(\d+\)\s*/).dispatchEvent("click");
+  await page
+    .getByRole("button")
+    .filter({
+      has: page.getByRole("checkbox", { checked: true }),
+      hasText: /^2\s*\d+\s*/,
+    })
+    .first()
+    .dispatchEvent("click");
+
+  await page.waitForTimeout(1000);
+  await expect(page).not.toHaveURL(/filter=/);
+});

--- a/e2e/hprc-tabs.ts
+++ b/e2e/hprc-tabs.ts
@@ -1,6 +1,8 @@
 import { HprcTabCollection } from "./testInterfaces";
 
 const SEARCH_FILTERS_PLACEHOLDER_TEXT = "Search all filters...";
+const DEFAULT_RELEASE_FILTER =
+  "%5B%7B%22categoryKey%22%3A%22release%22%2C%22value%22%3A%5B%222%22%5D%7D%5D";
 
 export const HPRC_TABS: HprcTabCollection = {
   alignments: {
@@ -15,14 +17,14 @@ export const HPRC_TABS: HprcTabCollection = {
     searchFiltersPlaceholderText: SEARCH_FILTERS_PLACEHOLDER_TEXT,
     selectableColumns: [],
     tabName: "Annotations",
-    url: "/annotations",
+    url: `/annotations?filter=${DEFAULT_RELEASE_FILTER}`,
   },
   assemblies: {
     preselectedColumns: [],
     searchFiltersPlaceholderText: SEARCH_FILTERS_PLACEHOLDER_TEXT,
     selectableColumns: [],
     tabName: "Assemblies",
-    url: "/assemblies",
+    url: `/assemblies?filter=${DEFAULT_RELEASE_FILTER}`,
   },
   rawSequencingData: {
     preselectedColumns: [],

--- a/e2e/testFunctions.ts
+++ b/e2e/testFunctions.ts
@@ -138,7 +138,6 @@ export async function testFilterPresence(
     await expect(page.getByText(filterRegex(filterName))).toBeVisible();
     await page.getByText(filterRegex(filterName)).dispatchEvent("click");
     await expect(page.getByRole("checkbox").first()).toBeVisible();
-    await expect(page.getByRole("checkbox").first()).not.toBeChecked();
     // Check that clicking out of the filter menu causes it to disappear
     await page.locator("body").click();
     await expect(page.getByRole("checkbox")).toHaveCount(0);

--- a/pages/[entityListType]/index.tsx
+++ b/pages/[entityListType]/index.tsx
@@ -1,16 +1,24 @@
 import { AzulEntitiesStaticResponse } from "@databiosphere/findable-ui/lib/apis/azul/common/entities";
+import {
+  CategoryValueKey,
+  SelectedFilter,
+} from "@databiosphere/findable-ui/lib/common/entities";
 import { Main as DXMain } from "@databiosphere/findable-ui/lib/components/Layout/components/Main/main.styles";
 import { EntityConfig } from "@databiosphere/findable-ui/lib/config/entities";
 import { getEntityConfig } from "@databiosphere/findable-ui/lib/config/utils";
 import { getEntityService } from "@databiosphere/findable-ui/lib/hooks/useEntityService";
 import { EXPLORE_MODE } from "@databiosphere/findable-ui/lib/hooks/useExploreMode/types";
+import { useExploreState } from "@databiosphere/findable-ui/lib/hooks/useExploreState";
+import { ExploreActionKind } from "@databiosphere/findable-ui/lib/providers/exploreState";
 import { database } from "@databiosphere/findable-ui/lib/utils/database";
 import { ExploreView } from "@databiosphere/findable-ui/lib/views/ExploreView/exploreView";
 import { config } from "app/config/config";
 import fsp from "fs/promises";
 import { GetStaticPaths, GetStaticProps, GetStaticPropsContext } from "next";
+import { useRouter } from "next/router";
 import { ParsedUrlQuery } from "querystring";
-import type { JSX } from "react";
+import { useEffect, useRef, type JSX } from "react";
+import { HPRC_DATA_EXPLORER_CATEGORY_KEY } from "../../site-config/hprc-data-explorer/category";
 
 interface PageUrl extends ParsedUrlQuery {
   entityListType: string;
@@ -18,6 +26,28 @@ interface PageUrl extends ParsedUrlQuery {
 
 interface ListPageProps extends AzulEntitiesStaticResponse {
   entityListType: string;
+}
+
+const DEFAULT_FILTERS_BY_ENTITY_LIST_TYPE: Record<string, SelectedFilter[]> = {
+  annotations: [
+    {
+      categoryKey: HPRC_DATA_EXPLORER_CATEGORY_KEY.RELEASE,
+      value: ["2"],
+    },
+  ],
+  assemblies: [
+    {
+      categoryKey: HPRC_DATA_EXPLORER_CATEGORY_KEY.RELEASE,
+      value: ["2"],
+    },
+  ],
+};
+
+const SESSION_STORAGE_DEFAULT_FILTER_INITIALIZED_PREFIX =
+  "hprc-data-explorer:default-filter-initialized:";
+
+function getDefaultFilterInitializedStorageKey(entityListType: string): string {
+  return `${SESSION_STORAGE_DEFAULT_FILTER_INITIALIZED_PREFIX}${entityListType}`;
 }
 
 /**
@@ -61,7 +91,59 @@ const IndexPage = ({
   entityListType,
   ...props
 }: ListPageProps): JSX.Element => {
+  const router = useRouter();
+  const { exploreDispatch, exploreState } = useExploreState();
+  const defaultFilters = DEFAULT_FILTERS_BY_ENTITY_LIST_TYPE[entityListType];
+  const injectedEntityListTypeRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!router.isReady || !defaultFilters) return;
+    if (exploreState.tabValue !== entityListType) return;
+
+    const initializedStorageKey =
+      getDefaultFilterInitializedStorageKey(entityListType);
+
+    if (typeof router.query.filter !== "undefined") {
+      if (typeof window !== "undefined") {
+        window.sessionStorage.setItem(initializedStorageKey, "true");
+      }
+      return;
+    }
+    if (
+      typeof window !== "undefined" &&
+      window.sessionStorage.getItem(initializedStorageKey)
+    ) {
+      return;
+    }
+    if (injectedEntityListTypeRef.current === entityListType) return;
+
+    injectedEntityListTypeRef.current = entityListType;
+    if (typeof window !== "undefined") {
+      window.sessionStorage.setItem(initializedStorageKey, "true");
+    }
+
+    defaultFilters.forEach(({ categoryKey, value }) => {
+      value.forEach((selectedValue) => {
+        exploreDispatch({
+          payload: {
+            categoryKey,
+            selected: true,
+            selectedValue: selectedValue as CategoryValueKey,
+          },
+          type: ExploreActionKind.UpdateFilter,
+        });
+      });
+    });
+  }, [
+    defaultFilters,
+    entityListType,
+    exploreDispatch,
+    exploreState.tabValue,
+    router,
+  ]);
+
   if (!entityListType) return <></>;
+
   return <ExploreView entityListType={entityListType} {...props} />;
 };
 


### PR DESCRIPTION
## Summary

  Apply a default `Release = 2` filter on first entry to the `Assemblies` and `Annotations` views.

  ## Behavior

  - First entry to `Assemblies` in a browser session defaults the `Release` filter to `2`
  - First entry to `Annotations` in a browser session defaults the `Release` filter to `2`
  - The default is only applied once per tab per browser session
  - After a user changes or clears the filter, that choice is respected
  - Normal cross-tab navigation behavior is preserved

  ## Implementation

  - Applies the default through the app's normal explore/filter state update path
  - Avoids an extra client-side route replace on page load
  - Tracks whether the default has already been initialized for each entity type in session storage

  ## Tests

  - Added a regression test for default filter application on `Assemblies` and `Annotations`
  - Added a regression test to confirm the default `Assemblies` filter can be cleared and stays cleared
  - Updated existing e2e filter fixtures to match the new default-filter behavior

  ## Verification

  Verified locally that:
  - entering `Assemblies` first applies `Release = 2`
  - entering `Annotations` first applies `Release = 2`
  - navigating from `Sequencing Data` to `Assemblies` and then `Annotations` applies the default on first entry to each
  - clearing/changing the filter is respected afterward
  - full Playwright suite passes locally
