### PR TITLE
feat: add styled footer with align-items flex-end

### DIFF
--- a/app/components/Layout/components/Footer/footer.styles.ts
+++ b/app/components/Layout/components/Footer/footer.styles.ts
@@ -1,0 +1,6 @@
+import { Footer } from "@databiosphere/findable-ui/lib/components/Layout/components/Footer/footer";
+import styled from "@emotion/styled";
+
+export const StyledFooter = styled(Footer)`
+  align-items: flex-end;
+`;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,25 +1,25 @@
 import "@databiosphere/findable-ui";
 import { AzulEntitiesStaticResponse } from "@databiosphere/findable-ui/lib/apis/azul/common/entities";
-import type { JSX } from "react";
 import { Error } from "@databiosphere/findable-ui/lib/components/Error/error";
 import { ErrorBoundary } from "@databiosphere/findable-ui/lib/components/ErrorBoundary";
 import { Head } from "@databiosphere/findable-ui/lib/components/Head/head";
 import { AppLayout } from "@databiosphere/findable-ui/lib/components/Layout/components/AppLayout/appLayout.styles";
 import { Floating } from "@databiosphere/findable-ui/lib/components/Layout/components/Floating/floating";
-import { Footer } from "@databiosphere/findable-ui/lib/components/Layout/components/Footer/footer";
 import { Header as DXHeader } from "@databiosphere/findable-ui/lib/components/Layout/components/Header/header";
 import { Main as DXMain } from "@databiosphere/findable-ui/lib/components/Layout/components/Main/main";
 import { ConfigProvider as DXConfigProvider } from "@databiosphere/findable-ui/lib/providers/config";
-import { GoogleSignInAuthenticationProvider } from "@databiosphere/findable-ui/lib/providers/googleSignInAuthentication/provider";
 import { ExploreStateProvider } from "@databiosphere/findable-ui/lib/providers/exploreState";
+import { GoogleSignInAuthenticationProvider } from "@databiosphere/findable-ui/lib/providers/googleSignInAuthentication/provider";
 import { LayoutDimensionsProvider } from "@databiosphere/findable-ui/lib/providers/layoutDimensions/provider";
 import { SystemStatusProvider } from "@databiosphere/findable-ui/lib/providers/systemStatus";
 import { createAppTheme } from "@databiosphere/findable-ui/lib/theme/theme";
 import { DataExplorerError } from "@databiosphere/findable-ui/lib/types/error";
 import { ThemeProvider as EmotionThemeProvider } from "@emotion/react";
 import { CssBaseline, ThemeProvider } from "@mui/material";
+import { StyledFooter } from "app/components/Layout/components/Footer/footer.styles";
 import { NextPage } from "next";
 import type { AppProps } from "next/app";
+import type { JSX } from "react";
 import { config } from "../app/config/config";
 
 export interface PageProps extends AzulEntitiesStaticResponse {
@@ -76,7 +76,7 @@ function MyApp({ Component, pageProps }: AppPropsWithComponent): JSX.Element {
                       </ErrorBoundary>
                     </Main>
                   </ExploreStateProvider>
-                  <Footer {...footer} />
+                  <StyledFooter {...footer} />
                 </AppLayout>
               </LayoutDimensionsProvider>
             </GoogleSignInAuthenticationProvider>


### PR DESCRIPTION
## Summary
- Adds a styled `Footer` component with `align-items: flex-end` to align footer content to the bottom
- Replaces the upstream `Footer` import with a local `StyledFooter` wrapper in `_app.tsx`
- Sorts imports alphabetically in `_app.tsx`

Closes #229

## Test plan
- [x] Verify footer content aligns to the bottom as expected
- [x] Check footer layout at various breakpoints (mobile, tablet, desktop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1535" height="1281" alt="image" src="https://github.com/user-attachments/assets/88765135-a436-4d33-8a90-c92b9bee32ba" />

<img width="589" height="1281" alt="image" src="https://github.com/user-attachments/assets/c14670ea-7458-46db-ac01-c8620d6e5292" />
