### PR TITLE
chore: enable eslint in catalog build folder (#238)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,7 +2,7 @@
 **/out/*
 **/.next/*
 
-build
+/build
 
 venv
 

--- a/catalog/build/ts/build-catalog.ts
+++ b/catalog/build/ts/build-catalog.ts
@@ -164,9 +164,9 @@ async function buildRawSequencingData(
         bioprojectAccession: parseStringOrAbsent(row.bioproject_accession),
         biosampleAccession: sample.biosampleAccession,
         ccsAlgorithm: parseStringOrAbsent(row.ccs_algorithm),
+        contributors: sample.contributors,
         coverage: parseNumberOrAbsent(row.coverage),
         familyId: sample.familyId,
-        contributors: sample.contributors,
         filename: parseStringOrAbsent(row.filename),
         filetype: parseStringOrAbsent(row.filetype),
         generatorContact: parseStringOrAbsent(row.generator_contact),
@@ -321,33 +321,6 @@ function enforceUniqueIds<T>(
       `Removed ${pluralEntityName} with duplicate IDs: ${deduplicatedIdsArr.join(", ")}`
     );
   return [filteredEntities, deduplicatedIdsArr];
-}
-
-/**
- * Take a list of entities and check for duplicate IDs, as calculated by the given function, and throw an error if there are any.
- * @param entityName - Name of the entity type, to use in the error message.
- * @param entities - Array of entities.
- * @param getId - Function to get an entity's ID.
- */
-function verifyUniqueIds<T>(
-  entityName: string,
-  entities: T[],
-  getId: (entity: T) => string
-): void {
-  const idCounts = new Map<string, number>();
-  for (const entity of entities) {
-    const id = getId(entity);
-    idCounts.set(id, (idCounts.get(id) ?? 0) + 1);
-  }
-  const duplicateIdEntries = Array.from(idCounts.entries()).filter(
-    ([, count]) => count > 1
-  );
-  if (duplicateIdEntries.length > 0) {
-    const duplicateIds = duplicateIdEntries.map(([id]) => id);
-    throw new Error(
-      `Duplicate ${entityName} IDs found: ${duplicateIds.join(", ")}`
-    );
-  }
 }
 
 function getSampleOrDefault(

--- a/catalog/build/ts/reports.ts
+++ b/catalog/build/ts/reports.ts
@@ -24,14 +24,14 @@ interface CatalogConversionReport {
 }
 
 interface EntityNormalizationReport {
-  validation_errors: Array<{
-    filename: string;
-    errors: string[];
-  }>;
   file_uri_errors: Array<{
-    uri: string;
     message: string;
+    uri: string;
   }> | null;
+  validation_errors: Array<{
+    errors: string[];
+    filename: string;
+  }>;
 }
 
 const REPORTS_PATH = "./catalog/build/reports";
@@ -96,14 +96,18 @@ export async function generateCatalogBuildReport(): Promise<void> {
     );
     report += `\n\n### Validation errors\n\n${generateListOrNone(
       filesWithErrors,
-      ({ filename, errors }) => {
+      ({ errors, filename }) => {
         return `${filename}:\n${generateStringList(errors, "  ")}`;
       }
     )}`;
 
     // File URI errors
     if (normalizationReport.file_uri_errors !== null) {
-      report += `\n\n### File URI errors\n\n${generateListOrNone(normalizationReport.file_uri_errors, ({ uri, message }) => `\`${uri}\`: ${message}`)}`;
+      const listText = generateListOrNone(
+        normalizationReport.file_uri_errors,
+        ({ message, uri }) => `\`${uri}\`: ${message}`
+      );
+      report += `\n\n### File URI errors\n\n${listText}`;
     }
 
     // Missing samples


### PR DESCRIPTION
Closes #238

My solution here to the eslintignore problem is to just update it to match only a top-level `build` folder, which matches the prettierignore and gitignore, although I'm not sure whether a top-level `build` folder ever actually exists

Fixing the resulting linting errors consisted of:
- Sorting some object keys
- Unnesting some template strings
- Removing the unused `verifyUniqueIds`