### PR TITLE
chore: enable `prettier-plugin-organize-imports` (#240)

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,3 +1,4 @@
 {
-  "trailingComma": "es5"
+  "trailingComma": "es5",
+  "plugins": ["prettier-plugin-organize-imports"]
 }

--- a/app/components/index.ts
+++ b/app/components/index.ts
@@ -1,10 +1,10 @@
 export { Alert } from "@databiosphere/findable-ui/lib/components/common/Alert/alert";
-export { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
 export { GitHubIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/GitHubIcon/gitHubIcon";
+export { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
 export { Logo } from "@databiosphere/findable-ui/lib/components/Layout/components/Header/components/Content/components/Logo/logo";
 export { BasicCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/BasicCell/basicCell";
 export { LinkCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/LinkCell/linkCell";
 export { NTagCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/NTagCell/nTagCell";
 export { FileDownload } from "./Index/components/FileDownload/fileDownload";
-export { TypographyNoWrap } from "./Table/components/TableCell/components/TypographyNoWrap/typographyNoWrap";
 export { LabelIconMenuItem } from "./Layout/components/Header/components/Content/components/Navigation/components/NavigationMenuItems/components/LabelIconMenuItem/labelIconMenuItem";
+export { TypographyNoWrap } from "./Table/components/TableCell/components/TypographyNoWrap/typographyNoWrap";

--- a/app/viewModelBuilders/catalog/hprc-data-explorer/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hprc-data-explorer/common/viewModelBuilders.ts
@@ -1,4 +1,7 @@
+import { ALERT_PROPS } from "@databiosphere/findable-ui/lib/components/common/Alert/constants";
+import { ViewContext } from "@databiosphere/findable-ui/lib/config/entities";
 import { formatFileSize } from "@databiosphere/findable-ui/lib/utils/formatFileSize";
+import { LinkProps } from "@mui/material";
 import {
   HPRCDataExplorerAlignment,
   HPRCDataExplorerAnnotation,
@@ -8,11 +11,8 @@ import {
   HPRCDataExplorerSample,
   LABEL,
 } from "../../../../apis/catalog/hprc-data-explorer/common/entities";
-import * as C from "../../../../components/index";
-import { ViewContext } from "@databiosphere/findable-ui/lib/config/entities";
 import * as MDX from "../../../../components/common/MDXContent";
-import { ALERT_PROPS } from "@databiosphere/findable-ui/lib/components/common/Alert/constants";
-import { LinkProps } from "@mui/material";
+import * as C from "../../../../components/index";
 
 /**
  * Build props for the accession cell.


### PR DESCRIPTION
Closes #240