### PR TITLE
fix: migrate dead columnVisible props to initialState.columnVisibility

### DIFF
--- a/site-config/hprc-data-explorer/local/index/alignmentEntityConfig.ts
+++ b/site-config/hprc-data-explorer/local/index/alignmentEntityConfig.ts
@@ -96,7 +96,6 @@ export const alignmentEntityConfig: EntityConfig<HPRCDataExplorerAlignment> = {
         width: { max: "0.5fr", min: "112px" },
       },
       {
-        columnVisible: false,
         componentConfig: {
           component: C.BasicCell,
           viewBuilder: V.buildVersion,
@@ -155,6 +154,7 @@ export const alignmentEntityConfig: EntityConfig<HPRCDataExplorerAlignment> = {
       initialState: {
         columnVisibility: {
           [HPRC_DATA_EXPLORER_CATEGORY_KEY.FILETYPE]: false,
+          [HPRC_DATA_EXPLORER_CATEGORY_KEY.HPRC_VERSION]: false,
         },
         expanded: true,
         grouping: [HPRC_DATA_EXPLORER_CATEGORY_KEY.ALIGNMENT],

--- a/site-config/hprc-data-explorer/local/index/annotationEntityConfig.ts
+++ b/site-config/hprc-data-explorer/local/index/annotationEntityConfig.ts
@@ -143,7 +143,6 @@ export const annotationEntityConfig: EntityConfig<HPRCDataExplorerAnnotation> =
           width: { max: "1fr", min: "160px" },
         },
         {
-          columnVisible: true,
           componentConfig: {
             component: C.TypographyNoWrap,
             viewBuilder: V.buildFileLocation,
@@ -157,7 +156,6 @@ export const annotationEntityConfig: EntityConfig<HPRCDataExplorerAnnotation> =
           width: { max: "1fr", min: "112px" },
         },
         {
-          columnVisible: true,
           componentConfig: {
             component: C.BasicCell,
             viewBuilder: V.buildBiosampleAccession,
@@ -168,7 +166,6 @@ export const annotationEntityConfig: EntityConfig<HPRCDataExplorerAnnotation> =
           width: { max: "1fr", min: "160px" },
         },
         {
-          columnVisible: false,
           componentConfig: {
             component: C.BasicCell,
             viewBuilder: V.buildFamilyId,
@@ -179,7 +176,6 @@ export const annotationEntityConfig: EntityConfig<HPRCDataExplorerAnnotation> =
           width: { max: "0.5fr", min: "112px" },
         },
         {
-          columnVisible: false,
           componentConfig: {
             component: C.BasicCell,
             viewBuilder: V.buildPopulationAbbreviation,
@@ -190,7 +186,6 @@ export const annotationEntityConfig: EntityConfig<HPRCDataExplorerAnnotation> =
           width: { max: "0.5fr", min: "112px" },
         },
         {
-          columnVisible: false,
           componentConfig: {
             component: C.BasicCell,
             viewBuilder: V.buildPopulationDescriptor,
@@ -201,7 +196,6 @@ export const annotationEntityConfig: EntityConfig<HPRCDataExplorerAnnotation> =
           width: { max: "1fr", min: "160px" },
         },
         {
-          columnVisible: false,
           componentConfig: {
             component: C.BasicCell,
             viewBuilder: V.buildProject,
@@ -212,7 +206,6 @@ export const annotationEntityConfig: EntityConfig<HPRCDataExplorerAnnotation> =
           width: { max: "1fr", min: "160px" },
         },
         {
-          columnVisible: false,
           componentConfig: {
             component: C.BasicCell,
             viewBuilder: V.buildContributors,
@@ -229,6 +222,13 @@ export const annotationEntityConfig: EntityConfig<HPRCDataExplorerAnnotation> =
         enableGrouping: true,
         enableTableDownload: true,
         initialState: {
+          columnVisibility: {
+            [HPRC_DATA_EXPLORER_CATEGORY_KEY.CONTRIBUTORS]: false,
+            [HPRC_DATA_EXPLORER_CATEGORY_KEY.FAMILY_ID]: false,
+            [HPRC_DATA_EXPLORER_CATEGORY_KEY.POPULATION_ABBREVIATION]: false,
+            [HPRC_DATA_EXPLORER_CATEGORY_KEY.POPULATION_DESCRIPTOR]: false,
+            [HPRC_DATA_EXPLORER_CATEGORY_KEY.PROJECT]: false,
+          },
           expanded: true,
           sorting: [
             {

--- a/site-config/hprc-data-explorer/local/index/assemblyEntityConfig.ts
+++ b/site-config/hprc-data-explorer/local/index/assemblyEntityConfig.ts
@@ -131,7 +131,6 @@ export const assemblyEntityConfig: EntityConfig<HPRCDataExplorerAssembly> = {
         width: { max: "0.5fr", min: "112px" },
       },
       {
-        columnVisible: true,
         componentConfig: {
           component: C.TypographyNoWrap,
           viewBuilder: V.buildAwsFasta,
@@ -145,7 +144,6 @@ export const assemblyEntityConfig: EntityConfig<HPRCDataExplorerAssembly> = {
         width: { max: "1fr", min: "112px" },
       },
       {
-        columnVisible: true,
         componentConfig: {
           component: C.BasicCell,
           viewBuilder: V.buildBiosampleAccession,
@@ -156,7 +154,6 @@ export const assemblyEntityConfig: EntityConfig<HPRCDataExplorerAssembly> = {
         width: { max: "1fr", min: "160px" },
       },
       {
-        columnVisible: false,
         componentConfig: {
           component: C.BasicCell,
           viewBuilder: V.buildFamilyId,
@@ -167,7 +164,6 @@ export const assemblyEntityConfig: EntityConfig<HPRCDataExplorerAssembly> = {
         width: { max: "0.5fr", min: "112px" },
       },
       {
-        columnVisible: true,
         componentConfig: {
           component: C.TypographyNoWrap,
           viewBuilder: V.buildFastaMd5,
@@ -181,7 +177,6 @@ export const assemblyEntityConfig: EntityConfig<HPRCDataExplorerAssembly> = {
         width: { max: "1fr", min: "112px" },
       },
       {
-        columnVisible: false,
         componentConfig: {
           component: C.TypographyNoWrap,
           viewBuilder: V.buildFastaSha256,
@@ -195,7 +190,6 @@ export const assemblyEntityConfig: EntityConfig<HPRCDataExplorerAssembly> = {
         width: { max: "1fr", min: "112px" },
       },
       {
-        columnVisible: false,
         componentConfig: {
           component: C.BasicCell,
           viewBuilder: V.buildPopulationAbbreviation,
@@ -206,7 +200,6 @@ export const assemblyEntityConfig: EntityConfig<HPRCDataExplorerAssembly> = {
         width: { max: "0.5fr", min: "112px" },
       },
       {
-        columnVisible: false,
         componentConfig: {
           component: C.BasicCell,
           viewBuilder: V.buildPopulationDescriptor,
@@ -217,7 +210,6 @@ export const assemblyEntityConfig: EntityConfig<HPRCDataExplorerAssembly> = {
         width: { max: "1fr", min: "160px" },
       },
       {
-        columnVisible: false,
         componentConfig: {
           component: C.BasicCell,
           viewBuilder: V.buildProject,
@@ -228,7 +220,6 @@ export const assemblyEntityConfig: EntityConfig<HPRCDataExplorerAssembly> = {
         width: { max: "1fr", min: "160px" },
       },
       {
-        columnVisible: false,
         componentConfig: {
           component: C.BasicCell,
           viewBuilder: V.buildContributors,
@@ -245,6 +236,14 @@ export const assemblyEntityConfig: EntityConfig<HPRCDataExplorerAssembly> = {
       enableGrouping: true,
       enableTableDownload: true,
       initialState: {
+        columnVisibility: {
+          [HPRC_DATA_EXPLORER_CATEGORY_KEY.CONTRIBUTORS]: false,
+          [HPRC_DATA_EXPLORER_CATEGORY_KEY.FAMILY_ID]: false,
+          [HPRC_DATA_EXPLORER_CATEGORY_KEY.FASTA_SHA256]: false,
+          [HPRC_DATA_EXPLORER_CATEGORY_KEY.POPULATION_ABBREVIATION]: false,
+          [HPRC_DATA_EXPLORER_CATEGORY_KEY.POPULATION_DESCRIPTOR]: false,
+          [HPRC_DATA_EXPLORER_CATEGORY_KEY.PROJECT]: false,
+        },
         expanded: true,
         sorting: [
           {

--- a/site-config/hprc-data-explorer/local/index/rawSequencingDataEntityConfig.ts
+++ b/site-config/hprc-data-explorer/local/index/rawSequencingDataEntityConfig.ts
@@ -149,7 +149,6 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
           width: { max: "0.5fr", min: "112px" },
         },
         {
-          columnVisible: false,
           componentConfig: {
             component: C.BasicCell,
             viewBuilder: V.buildFamilyId,
@@ -163,7 +162,6 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
           width: { max: "0.5fr", min: "112px" },
         },
         {
-          columnVisible: false,
           componentConfig: {
             component: C.BasicCell,
             viewBuilder: V.buildPopulationAbbreviation,
@@ -177,7 +175,6 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
           width: { max: "0.5fr", min: "112px" },
         },
         {
-          columnVisible: false,
           componentConfig: {
             component: C.BasicCell,
             viewBuilder: V.buildPopulationDescriptor,
@@ -191,7 +188,6 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
           width: { max: "1fr", min: "160px" },
         },
         {
-          columnVisible: false,
           componentConfig: {
             component: C.BasicCell,
             viewBuilder: V.buildBiosampleAccession,
@@ -205,7 +201,6 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
           width: { max: "0.5fr", min: "112px" },
         },
         {
-          columnVisible: false,
           componentConfig: {
             component: C.BasicCell,
             viewBuilder: V.buildProject,
@@ -219,7 +214,6 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
           width: { max: "1fr", min: "160px" },
         },
         {
-          columnVisible: false,
           componentConfig: {
             component: C.BasicCell,
             viewBuilder: V.buildContributors,
@@ -259,7 +253,6 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
           width: { max: "1fr", min: "160px" },
         },
         {
-          columnVisible: false,
           componentConfig: {
             component: C.BasicCell,
             viewBuilder: V.buildBasecaller,
@@ -273,7 +266,6 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
           width: { max: "0.5fr", min: "112px" },
         },
         {
-          columnVisible: false,
           componentConfig: {
             component: C.BasicCell,
             viewBuilder: V.buildBasecallerModel,
@@ -287,7 +279,6 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
           width: { max: "1fr", min: "160px" },
         },
         {
-          columnVisible: false,
           componentConfig: {
             component: C.BasicCell,
             viewBuilder: V.buildBasecallerVersion,
@@ -301,7 +292,6 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
           width: { max: "0.5fr", min: "112px" },
         },
         {
-          columnVisible: false,
           componentConfig: {
             component: C.BasicCell,
             viewBuilder: V.buildBioprojectAccession,
@@ -315,7 +305,6 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
           width: { max: "0.5fr", min: "112px" },
         },
         {
-          columnVisible: false,
           componentConfig: {
             component: C.BasicCell,
             viewBuilder: V.buildCcsAlgorithm,
@@ -329,7 +318,6 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
           width: { max: "1fr", min: "160px" },
         },
         {
-          columnVisible: false,
           componentConfig: {
             component: C.BasicCell,
             viewBuilder: V.buildFiletype,
@@ -343,7 +331,6 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
           width: { max: "0.5fr", min: "112px" },
         },
         {
-          columnVisible: false,
           componentConfig: {
             component: C.BasicCell,
             viewBuilder: V.buildGeneratorContact,
@@ -357,7 +344,6 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
           width: { max: "1fr", min: "160px" },
         },
         {
-          columnVisible: false,
           componentConfig: {
             component: C.BasicCell,
             viewBuilder: V.buildGeneratorFacility,
@@ -371,7 +357,6 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
           width: { max: "1fr", min: "160px" },
         },
         {
-          columnVisible: false,
           componentConfig: {
             component: C.BasicCell,
             viewBuilder: V.buildLibrarySource,
@@ -385,7 +370,6 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
           width: { max: "0.5fr", min: "112px" },
         },
         {
-          columnVisible: false,
           componentConfig: {
             component: C.BasicCell,
             viewBuilder: V.buildLibraryStrategy,
@@ -399,7 +383,6 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
           width: { max: "0.5fr", min: "112px" },
         },
         {
-          columnVisible: false,
           componentConfig: {
             component: C.BasicCell,
             viewBuilder: V.buildMmTag,
@@ -413,7 +396,6 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
           width: { max: "0.5fr", min: "112px" },
         },
         {
-          columnVisible: false,
           componentConfig: {
             component: C.BasicCell,
             viewBuilder: V.buildN50,
@@ -427,7 +409,6 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
           width: { max: "0.5fr", min: "112px" },
         },
         {
-          columnVisible: false,
           componentConfig: {
             component: C.BasicCell,
             viewBuilder: V.buildOneHundredkbPlus,
@@ -441,7 +422,6 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
           width: { max: "0.5fr", min: "112px" },
         },
         {
-          columnVisible: true,
           componentConfig: {
             component: C.TypographyNoWrap,
             viewBuilder: V.buildPath,
@@ -455,7 +435,6 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
           width: { max: "1fr", min: "112px" },
         },
         {
-          columnVisible: false,
           componentConfig: {
             component: C.BasicCell,
             viewBuilder: V.buildStudy,
@@ -469,7 +448,6 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
           width: { max: "0.5fr", min: "120px" },
         },
         {
-          columnVisible: false,
           componentConfig: {
             component: C.BasicCell,
             viewBuilder: V.buildTotalGbp,
@@ -483,7 +461,6 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
           width: { max: "0.5fr", min: "144px" },
         },
         {
-          columnVisible: false,
           componentConfig: {
             component: C.BasicCell,
             viewBuilder: V.buildTotalReads,
@@ -497,7 +474,6 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
           width: { max: "0.5fr", min: "112px" },
         },
         {
-          columnVisible: false,
           componentConfig: {
             component: C.BasicCell,
             viewBuilder: V.buildWhales,
@@ -517,6 +493,31 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
         enableGrouping: true,
         enableTableDownload: true,
         initialState: {
+          columnVisibility: {
+            [HPRC_DATA_EXPLORER_CATEGORY_KEY.BASECALLER]: false,
+            [HPRC_DATA_EXPLORER_CATEGORY_KEY.BASECALLER_MODEL]: false,
+            [HPRC_DATA_EXPLORER_CATEGORY_KEY.BASECALLER_VERSION]: false,
+            [HPRC_DATA_EXPLORER_CATEGORY_KEY.BIOPROJECT_ACCESSION]: false,
+            [HPRC_DATA_EXPLORER_CATEGORY_KEY.BIOSAMPLE_ACCESSION]: false,
+            [HPRC_DATA_EXPLORER_CATEGORY_KEY.CCS_ALGORITHM]: false,
+            [HPRC_DATA_EXPLORER_CATEGORY_KEY.CONTRIBUTORS]: false,
+            [HPRC_DATA_EXPLORER_CATEGORY_KEY.FAMILY_ID]: false,
+            [HPRC_DATA_EXPLORER_CATEGORY_KEY.FILETYPE]: false,
+            [HPRC_DATA_EXPLORER_CATEGORY_KEY.GENERATOR_CONTACT]: false,
+            [HPRC_DATA_EXPLORER_CATEGORY_KEY.GENERATOR_FACILITY]: false,
+            [HPRC_DATA_EXPLORER_CATEGORY_KEY.LIBRARY_SOURCE]: false,
+            [HPRC_DATA_EXPLORER_CATEGORY_KEY.LIBRARY_STRATEGY]: false,
+            [HPRC_DATA_EXPLORER_CATEGORY_KEY.MM_TAG]: false,
+            [HPRC_DATA_EXPLORER_CATEGORY_KEY.N50]: false,
+            [HPRC_DATA_EXPLORER_CATEGORY_KEY.ONE_HUNDRED_KB_PLUS]: false,
+            [HPRC_DATA_EXPLORER_CATEGORY_KEY.POPULATION_ABBREVIATION]: false,
+            [HPRC_DATA_EXPLORER_CATEGORY_KEY.POPULATION_DESCRIPTOR]: false,
+            [HPRC_DATA_EXPLORER_CATEGORY_KEY.PROJECT]: false,
+            [HPRC_DATA_EXPLORER_CATEGORY_KEY.STUDY]: false,
+            [HPRC_DATA_EXPLORER_CATEGORY_KEY.TOTAL_GBP]: false,
+            [HPRC_DATA_EXPLORER_CATEGORY_KEY.TOTAL_READS]: false,
+            [HPRC_DATA_EXPLORER_CATEGORY_KEY.WHALES]: false,
+          },
           expanded: true,
           sorting: [
             {

--- a/site-config/hprc-data-explorer/local/index/sampleEntityConfig.ts
+++ b/site-config/hprc-data-explorer/local/index/sampleEntityConfig.ts
@@ -82,7 +82,6 @@ export const sampleEntityConfig: EntityConfig<HPRCDataExplorerSample> = {
         width: { max: "0.5fr", min: "160px" },
       },
       {
-        columnVisible: true,
         componentConfig: {
           component: C.BasicCell,
           viewBuilder: V.buildBiosampleAccession,
@@ -93,7 +92,6 @@ export const sampleEntityConfig: EntityConfig<HPRCDataExplorerSample> = {
         width: { max: "1fr", min: "160px" },
       },
       {
-        columnVisible: false,
         componentConfig: {
           component: C.BasicCell,
           viewBuilder: V.buildFamilyId,
@@ -104,7 +102,6 @@ export const sampleEntityConfig: EntityConfig<HPRCDataExplorerSample> = {
         width: { max: "0.5fr", min: "112px" },
       },
       {
-        columnVisible: false,
         componentConfig: {
           component: C.BasicCell,
           viewBuilder: V.buildPopulationAbbreviation,
@@ -115,7 +112,6 @@ export const sampleEntityConfig: EntityConfig<HPRCDataExplorerSample> = {
         width: { max: "0.5fr", min: "112px" },
       },
       {
-        columnVisible: false,
         componentConfig: {
           component: C.BasicCell,
           viewBuilder: V.buildPopulationDescriptor,
@@ -126,7 +122,6 @@ export const sampleEntityConfig: EntityConfig<HPRCDataExplorerSample> = {
         width: { max: "1fr", min: "160px" },
       },
       {
-        columnVisible: false,
         componentConfig: {
           component: C.BasicCell,
           viewBuilder: V.buildProject,
@@ -137,7 +132,6 @@ export const sampleEntityConfig: EntityConfig<HPRCDataExplorerSample> = {
         width: { max: "1fr", min: "160px" },
       },
       {
-        columnVisible: false,
         componentConfig: {
           component: C.BasicCell,
           viewBuilder: V.buildContributors,
@@ -153,6 +147,13 @@ export const sampleEntityConfig: EntityConfig<HPRCDataExplorerSample> = {
       enableGrouping: true,
       enableTableDownload: true,
       initialState: {
+        columnVisibility: {
+          [HPRC_DATA_EXPLORER_CATEGORY_KEY.CONTRIBUTORS]: false,
+          [HPRC_DATA_EXPLORER_CATEGORY_KEY.FAMILY_ID]: false,
+          [HPRC_DATA_EXPLORER_CATEGORY_KEY.POPULATION_ABBREVIATION]: false,
+          [HPRC_DATA_EXPLORER_CATEGORY_KEY.POPULATION_DESCRIPTOR]: false,
+          [HPRC_DATA_EXPLORER_CATEGORY_KEY.PROJECT]: false,
+        },
         expanded: true,
         sorting: [
           {


### PR DESCRIPTION
## Summary
- Removes all dead `columnVisible` props (40 total) from the 5 entity config files — these were silently ignored by findable-ui
- Adds proper `tableOptions.initialState.columnVisibility` maps so columns marked `columnVisible: false` are now actually hidden by default
- Follows the existing working pattern in `alignmentEntityConfig.ts`

| Entity Config | Dead props removed | Columns now hidden |
|---|---|---|
| rawSequencingData | 24 | 23 |
| assembly | 9 | 6 |
| annotation | 7 | 5 |
| sample | 6 | 5 |
| alignment | 1 | 1 (added to existing map) |

Closes #246

## Test plan
- [x] Verify each entity tab hides the correct columns by default
- [x] Verify hidden columns can be toggled visible via column visibility controls
- [x] Spot-check: assemblies should hide Population Descriptor, Family ID, etc. by default
- [x] Spot-check: raw sequencing data should show only ~6 columns by default (was showing all 29)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2458" height="1196" alt="image" src="https://github.com/user-attachments/assets/3b9c4a3d-9aef-4d5d-b93a-f50a5deb26ee" />

<img width="2455" height="1204" alt="image" src="https://github.com/user-attachments/assets/510aeded-02d5-461e-85d3-9a72c0b9bfc9" />
