### PR TITLE
feat: sequencing data tab filters, column defaults, and metrics range group (#247)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "hprc-data-explorer",
       "version": "0.8.0",
       "dependencies": {
-        "@databiosphere/findable-ui": "^51.0.1",
+        "@databiosphere/findable-ui": "^51.0.2",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@mdx-js/loader": "^3.0.1",
@@ -1032,9 +1032,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "51.0.1",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-51.0.1.tgz",
-      "integrity": "sha512-kHHf38QoQUJP+LQAPFKmGuOdZWWeb8Fjer+1CgIa8CryAnGI4HGNQT1KetrnMP0KuPRVOw3VmQOtzsynSdauKg==",
+      "version": "51.0.2",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-51.0.2.tgz",
+      "integrity": "sha512-JkAVpi4+FD5wwJ+w4XHnisvn7Ur3Dkk0vCfCs15UM17h4DN7UWP+ae1eQpBoP1JssSbkiNzS0/R0X51TQxAXzw==",
       "license": "Apache-2.0",
       "engines": {
         "node": "22.12.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "gen-schema": "poetry run ./catalog/schema/scripts/gen-schema.sh"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^51.0.1",
+    "@databiosphere/findable-ui": "^51.0.2",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@mdx-js/loader": "^3.0.1",

--- a/site-config/hprc-data-explorer/category.ts
+++ b/site-config/hprc-data-explorer/category.ts
@@ -16,6 +16,7 @@ export const HPRC_DATA_EXPLORER_CATEGORY_KEY = {
   CCS_ALGORITHM: "ccsAlgorithm",
   COLLECTION: "collection",
   CONTRIBUTORS: "contributors",
+  COVERAGE: "coverage",
   DNA_BRNN_ANNOTATION_FILE: "dnaBrnnAnnotationFile",
   DOWNLOAD: "DOWNLOAD",
   FAMILY_ID: "familyId",
@@ -65,7 +66,7 @@ export const HPRC_DATA_EXPLORER_CATEGORY_KEY = {
 };
 
 export const HPRC_DATA_EXPLORER_CATEGORY_LABEL = {
-  ACCESSION: "Accession",
+  ACCESSION: "Run Accession",
   ALIGNMENT: "Alignment",
   ALIGNMENT_DOWNLOAD: "",
   ALTERNATIVE_ID: "Alternative ID",
@@ -82,6 +83,7 @@ export const HPRC_DATA_EXPLORER_CATEGORY_LABEL = {
   CCS_ALGORITHM: "CCS Algorithm",
   COLLECTION: "Collection",
   CONTRIBUTORS: "Contributors",
+  COVERAGE: "Coverage",
   DNA_BRNN_ANNOTATION_FILE: "DNA BRNN",
   DOWNLOAD: "",
   FAMILY_ID: "Family ID",

--- a/site-config/hprc-data-explorer/local/index/rawSequencingDataEntityConfig.ts
+++ b/site-config/hprc-data-explorer/local/index/rawSequencingDataEntityConfig.ts
@@ -1,3 +1,4 @@
+import { VIEW_KIND } from "@databiosphere/findable-ui/lib/common/categories/views/types";
 import {
   ComponentConfig,
   EntityConfig,
@@ -24,29 +25,41 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
         {
           categoryConfigs: [
             {
-              key: HPRC_DATA_EXPLORER_CATEGORY_KEY.ACCESSION,
-              label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.ACCESSION,
-            },
-            {
-              key: HPRC_DATA_EXPLORER_CATEGORY_KEY.BIOSAMPLE_ACCESSION,
-              label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.BIOSAMPLE_ACCESSION,
-            },
-          ],
-          label: "SRA",
-        },
-        {
-          categoryConfigs: [
-            {
-              key: HPRC_DATA_EXPLORER_CATEGORY_KEY.SAMPLE_ID,
-              label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.SAMPLE_ID,
-            },
-            {
               key: HPRC_DATA_EXPLORER_CATEGORY_KEY.PROJECT,
               label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.PROJECT,
             },
             {
               key: HPRC_DATA_EXPLORER_CATEGORY_KEY.CONTRIBUTORS,
               label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.CONTRIBUTORS,
+            },
+            {
+              key: HPRC_DATA_EXPLORER_CATEGORY_KEY.GENERATOR_FACILITY,
+              label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.GENERATOR_FACILITY,
+            },
+          ],
+          label: "Source",
+        },
+        {
+          categoryConfigs: [
+            {
+              key: HPRC_DATA_EXPLORER_CATEGORY_KEY.POPULATION_DESCRIPTOR,
+              label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.POPULATION_DESCRIPTOR,
+            },
+            {
+              key: HPRC_DATA_EXPLORER_CATEGORY_KEY.POPULATION_ABBREVIATION,
+              label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.POPULATION_ABBREVIATION,
+            },
+            {
+              key: HPRC_DATA_EXPLORER_CATEGORY_KEY.FAMILY_ID,
+              label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.FAMILY_ID,
+            },
+            {
+              key: HPRC_DATA_EXPLORER_CATEGORY_KEY.SAMPLE_ID,
+              label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.SAMPLE_ID,
+            },
+            {
+              key: HPRC_DATA_EXPLORER_CATEGORY_KEY.BIOSAMPLE_ACCESSION,
+              label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.BIOSAMPLE_ACCESSION,
             },
           ],
           label: "Sample",
@@ -66,6 +79,10 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
               label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.LIBRARY_STRATEGY,
             },
             {
+              key: HPRC_DATA_EXPLORER_CATEGORY_KEY.LIBRARY_SOURCE,
+              label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.LIBRARY_SOURCE,
+            },
+            {
               key: HPRC_DATA_EXPLORER_CATEGORY_KEY.FILETYPE,
               label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.FILETYPE,
             },
@@ -74,11 +91,58 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
               label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.BASECALLER,
             },
             {
+              key: HPRC_DATA_EXPLORER_CATEGORY_KEY.BASECALLER_MODEL,
+              label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.BASECALLER_MODEL,
+            },
+            {
               key: HPRC_DATA_EXPLORER_CATEGORY_KEY.BASECALLER_VERSION,
               label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.BASECALLER_VERSION,
             },
+            {
+              key: HPRC_DATA_EXPLORER_CATEGORY_KEY.CCS_ALGORITHM,
+              label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.CCS_ALGORITHM,
+            },
+            {
+              key: HPRC_DATA_EXPLORER_CATEGORY_KEY.ACCESSION,
+              label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.ACCESSION,
+            },
           ],
           label: "Sequencing",
+        },
+        {
+          categoryConfigs: [
+            {
+              key: HPRC_DATA_EXPLORER_CATEGORY_KEY.COVERAGE,
+              label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.COVERAGE,
+              viewKind: VIEW_KIND.RANGE,
+            },
+            {
+              key: HPRC_DATA_EXPLORER_CATEGORY_KEY.TOTAL_GBP,
+              label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.TOTAL_GBP,
+              viewKind: VIEW_KIND.RANGE,
+            },
+            {
+              key: HPRC_DATA_EXPLORER_CATEGORY_KEY.N50,
+              label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.N50,
+              viewKind: VIEW_KIND.RANGE,
+            },
+            {
+              key: HPRC_DATA_EXPLORER_CATEGORY_KEY.TOTAL_READS,
+              label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.TOTAL_READS,
+              viewKind: VIEW_KIND.RANGE,
+            },
+            {
+              key: HPRC_DATA_EXPLORER_CATEGORY_KEY.ONE_HUNDRED_KB_PLUS,
+              label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.ONE_HUNDRED_KB_PLUS,
+              viewKind: VIEW_KIND.RANGE,
+            },
+            {
+              key: HPRC_DATA_EXPLORER_CATEGORY_KEY.WHALES,
+              label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.WHALES,
+              viewKind: VIEW_KIND.RANGE,
+            },
+          ],
+          label: "Metrics",
         },
       ],
       key: "raw-sequencing-data",
@@ -151,28 +215,54 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
         {
           componentConfig: {
             component: C.BasicCell,
-            viewBuilder: V.buildFamilyId,
+            viewBuilder: V.buildBiosampleAccession,
           } as ComponentConfig<
             typeof C.BasicCell,
             HPRCDataExplorerRawSequencingData
           >,
           enableGrouping: true,
-          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.FAMILY_ID,
-          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.FAMILY_ID,
+          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.BIOSAMPLE_ACCESSION,
+          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.BIOSAMPLE_ACCESSION,
           width: { max: "0.5fr", min: "112px" },
         },
         {
           componentConfig: {
             component: C.BasicCell,
-            viewBuilder: V.buildPopulationAbbreviation,
+            viewBuilder: V.buildBioprojectAccession,
           } as ComponentConfig<
             typeof C.BasicCell,
             HPRCDataExplorerRawSequencingData
           >,
           enableGrouping: true,
-          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.POPULATION_ABBREVIATION,
-          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.POPULATION_ABBREVIATION,
+          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.BIOPROJECT_ACCESSION,
+          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.BIOPROJECT_ACCESSION,
           width: { max: "0.5fr", min: "112px" },
+        },
+        {
+          componentConfig: {
+            component: C.BasicCell,
+            viewBuilder: V.buildStudy,
+          } as ComponentConfig<
+            typeof C.BasicCell,
+            HPRCDataExplorerRawSequencingData
+          >,
+          enableGrouping: true,
+          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.STUDY,
+          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.STUDY,
+          width: { max: "0.5fr", min: "120px" },
+        },
+        {
+          componentConfig: {
+            component: C.TypographyNoWrap,
+            viewBuilder: V.buildPath,
+          } as ComponentConfig<
+            typeof C.TypographyNoWrap,
+            HPRCDataExplorerRawSequencingData
+          >,
+          enableGrouping: false,
+          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.PATH,
+          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.PATH,
+          width: { max: "1fr", min: "112px" },
         },
         {
           componentConfig: {
@@ -190,14 +280,27 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
         {
           componentConfig: {
             component: C.BasicCell,
-            viewBuilder: V.buildBiosampleAccession,
+            viewBuilder: V.buildPopulationAbbreviation,
           } as ComponentConfig<
             typeof C.BasicCell,
             HPRCDataExplorerRawSequencingData
           >,
           enableGrouping: true,
-          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.BIOSAMPLE_ACCESSION,
-          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.BIOSAMPLE_ACCESSION,
+          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.POPULATION_ABBREVIATION,
+          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.POPULATION_ABBREVIATION,
+          width: { max: "0.5fr", min: "112px" },
+        },
+        {
+          componentConfig: {
+            component: C.BasicCell,
+            viewBuilder: V.buildFamilyId,
+          } as ComponentConfig<
+            typeof C.BasicCell,
+            HPRCDataExplorerRawSequencingData
+          >,
+          enableGrouping: true,
+          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.FAMILY_ID,
+          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.FAMILY_ID,
           width: { max: "0.5fr", min: "112px" },
         },
         {
@@ -229,6 +332,19 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
         {
           componentConfig: {
             component: C.BasicCell,
+            viewBuilder: V.buildGeneratorFacility,
+          } as ComponentConfig<
+            typeof C.BasicCell,
+            HPRCDataExplorerRawSequencingData
+          >,
+          enableGrouping: true,
+          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.GENERATOR_FACILITY,
+          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.GENERATOR_FACILITY,
+          width: { max: "1fr", min: "160px" },
+        },
+        {
+          componentConfig: {
+            component: C.BasicCell,
             viewBuilder: V.buildPlatform,
           } as ComponentConfig<
             typeof C.BasicCell,
@@ -251,6 +367,45 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
           header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.INSTRUMENT_MODEL,
           id: HPRC_DATA_EXPLORER_CATEGORY_KEY.INSTRUMENT_MODEL,
           width: { max: "1fr", min: "160px" },
+        },
+        {
+          componentConfig: {
+            component: C.BasicCell,
+            viewBuilder: V.buildLibraryStrategy,
+          } as ComponentConfig<
+            typeof C.BasicCell,
+            HPRCDataExplorerRawSequencingData
+          >,
+          enableGrouping: true,
+          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.LIBRARY_STRATEGY,
+          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.LIBRARY_STRATEGY,
+          width: { max: "0.5fr", min: "112px" },
+        },
+        {
+          componentConfig: {
+            component: C.BasicCell,
+            viewBuilder: V.buildLibrarySource,
+          } as ComponentConfig<
+            typeof C.BasicCell,
+            HPRCDataExplorerRawSequencingData
+          >,
+          enableGrouping: true,
+          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.LIBRARY_SOURCE,
+          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.LIBRARY_SOURCE,
+          width: { max: "0.5fr", min: "112px" },
+        },
+        {
+          componentConfig: {
+            component: C.BasicCell,
+            viewBuilder: V.buildFiletype,
+          } as ComponentConfig<
+            typeof C.BasicCell,
+            HPRCDataExplorerRawSequencingData
+          >,
+          enableGrouping: true,
+          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.FILETYPE,
+          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.FILETYPE,
+          width: { max: "0.5fr", min: "112px" },
         },
         {
           componentConfig: {
@@ -294,19 +449,6 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
         {
           componentConfig: {
             component: C.BasicCell,
-            viewBuilder: V.buildBioprojectAccession,
-          } as ComponentConfig<
-            typeof C.BasicCell,
-            HPRCDataExplorerRawSequencingData
-          >,
-          enableGrouping: true,
-          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.BIOPROJECT_ACCESSION,
-          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.BIOPROJECT_ACCESSION,
-          width: { max: "0.5fr", min: "112px" },
-        },
-        {
-          componentConfig: {
-            component: C.BasicCell,
             viewBuilder: V.buildCcsAlgorithm,
           } as ComponentConfig<
             typeof C.BasicCell,
@@ -316,71 +458,6 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
           header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.CCS_ALGORITHM,
           id: HPRC_DATA_EXPLORER_CATEGORY_KEY.CCS_ALGORITHM,
           width: { max: "1fr", min: "160px" },
-        },
-        {
-          componentConfig: {
-            component: C.BasicCell,
-            viewBuilder: V.buildFiletype,
-          } as ComponentConfig<
-            typeof C.BasicCell,
-            HPRCDataExplorerRawSequencingData
-          >,
-          enableGrouping: true,
-          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.FILETYPE,
-          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.FILETYPE,
-          width: { max: "0.5fr", min: "112px" },
-        },
-        {
-          componentConfig: {
-            component: C.BasicCell,
-            viewBuilder: V.buildGeneratorContact,
-          } as ComponentConfig<
-            typeof C.BasicCell,
-            HPRCDataExplorerRawSequencingData
-          >,
-          enableGrouping: true,
-          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.GENERATOR_CONTACT,
-          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.GENERATOR_CONTACT,
-          width: { max: "1fr", min: "160px" },
-        },
-        {
-          componentConfig: {
-            component: C.BasicCell,
-            viewBuilder: V.buildGeneratorFacility,
-          } as ComponentConfig<
-            typeof C.BasicCell,
-            HPRCDataExplorerRawSequencingData
-          >,
-          enableGrouping: true,
-          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.GENERATOR_FACILITY,
-          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.GENERATOR_FACILITY,
-          width: { max: "1fr", min: "160px" },
-        },
-        {
-          componentConfig: {
-            component: C.BasicCell,
-            viewBuilder: V.buildLibrarySource,
-          } as ComponentConfig<
-            typeof C.BasicCell,
-            HPRCDataExplorerRawSequencingData
-          >,
-          enableGrouping: true,
-          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.LIBRARY_SOURCE,
-          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.LIBRARY_SOURCE,
-          width: { max: "0.5fr", min: "112px" },
-        },
-        {
-          componentConfig: {
-            component: C.BasicCell,
-            viewBuilder: V.buildLibraryStrategy,
-          } as ComponentConfig<
-            typeof C.BasicCell,
-            HPRCDataExplorerRawSequencingData
-          >,
-          enableGrouping: true,
-          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.LIBRARY_STRATEGY,
-          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.LIBRARY_STRATEGY,
-          width: { max: "0.5fr", min: "112px" },
         },
         {
           componentConfig: {
@@ -398,54 +475,15 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
         {
           componentConfig: {
             component: C.BasicCell,
-            viewBuilder: V.buildN50,
+            viewBuilder: V.buildCoverage,
           } as ComponentConfig<
             typeof C.BasicCell,
             HPRCDataExplorerRawSequencingData
           >,
           enableGrouping: true,
-          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.N50,
-          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.N50,
+          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.COVERAGE,
+          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.COVERAGE,
           width: { max: "0.5fr", min: "112px" },
-        },
-        {
-          componentConfig: {
-            component: C.BasicCell,
-            viewBuilder: V.buildOneHundredkbPlus,
-          } as ComponentConfig<
-            typeof C.BasicCell,
-            HPRCDataExplorerRawSequencingData
-          >,
-          enableGrouping: true,
-          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.ONE_HUNDRED_KB_PLUS,
-          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.ONE_HUNDRED_KB_PLUS,
-          width: { max: "0.5fr", min: "112px" },
-        },
-        {
-          componentConfig: {
-            component: C.TypographyNoWrap,
-            viewBuilder: V.buildPath,
-          } as ComponentConfig<
-            typeof C.TypographyNoWrap,
-            HPRCDataExplorerRawSequencingData
-          >,
-          enableGrouping: false,
-          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.PATH,
-          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.PATH,
-          width: { max: "1fr", min: "112px" },
-        },
-        {
-          componentConfig: {
-            component: C.BasicCell,
-            viewBuilder: V.buildStudy,
-          } as ComponentConfig<
-            typeof C.BasicCell,
-            HPRCDataExplorerRawSequencingData
-          >,
-          enableGrouping: true,
-          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.STUDY,
-          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.STUDY,
-          width: { max: "0.5fr", min: "120px" },
         },
         {
           componentConfig: {
@@ -463,6 +501,19 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
         {
           componentConfig: {
             component: C.BasicCell,
+            viewBuilder: V.buildN50,
+          } as ComponentConfig<
+            typeof C.BasicCell,
+            HPRCDataExplorerRawSequencingData
+          >,
+          enableGrouping: true,
+          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.N50,
+          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.N50,
+          width: { max: "0.5fr", min: "112px" },
+        },
+        {
+          componentConfig: {
+            component: C.BasicCell,
             viewBuilder: V.buildTotalReads,
           } as ComponentConfig<
             typeof C.BasicCell,
@@ -471,6 +522,19 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
           enableGrouping: true,
           header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.TOTAL_READS,
           id: HPRC_DATA_EXPLORER_CATEGORY_KEY.TOTAL_READS,
+          width: { max: "0.5fr", min: "112px" },
+        },
+        {
+          componentConfig: {
+            component: C.BasicCell,
+            viewBuilder: V.buildOneHundredkbPlus,
+          } as ComponentConfig<
+            typeof C.BasicCell,
+            HPRCDataExplorerRawSequencingData
+          >,
+          enableGrouping: true,
+          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.ONE_HUNDRED_KB_PLUS,
+          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.ONE_HUNDRED_KB_PLUS,
           width: { max: "0.5fr", min: "112px" },
         },
         {
@@ -485,6 +549,19 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
           header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.WHALES,
           id: HPRC_DATA_EXPLORER_CATEGORY_KEY.WHALES,
           width: { max: "0.5fr", min: "112px" },
+        },
+        {
+          componentConfig: {
+            component: C.BasicCell,
+            viewBuilder: V.buildGeneratorContact,
+          } as ComponentConfig<
+            typeof C.BasicCell,
+            HPRCDataExplorerRawSequencingData
+          >,
+          enableGrouping: true,
+          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.GENERATOR_CONTACT,
+          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.GENERATOR_CONTACT,
+          width: { max: "1fr", min: "160px" },
         },
       ],
       tableOptions: {
@@ -502,19 +579,16 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
             [HPRC_DATA_EXPLORER_CATEGORY_KEY.CCS_ALGORITHM]: false,
             [HPRC_DATA_EXPLORER_CATEGORY_KEY.CONTRIBUTORS]: false,
             [HPRC_DATA_EXPLORER_CATEGORY_KEY.FAMILY_ID]: false,
-            [HPRC_DATA_EXPLORER_CATEGORY_KEY.FILETYPE]: false,
             [HPRC_DATA_EXPLORER_CATEGORY_KEY.GENERATOR_CONTACT]: false,
             [HPRC_DATA_EXPLORER_CATEGORY_KEY.GENERATOR_FACILITY]: false,
             [HPRC_DATA_EXPLORER_CATEGORY_KEY.LIBRARY_SOURCE]: false,
-            [HPRC_DATA_EXPLORER_CATEGORY_KEY.LIBRARY_STRATEGY]: false,
             [HPRC_DATA_EXPLORER_CATEGORY_KEY.MM_TAG]: false,
-            [HPRC_DATA_EXPLORER_CATEGORY_KEY.N50]: false,
             [HPRC_DATA_EXPLORER_CATEGORY_KEY.ONE_HUNDRED_KB_PLUS]: false,
+            [HPRC_DATA_EXPLORER_CATEGORY_KEY.PATH]: false,
             [HPRC_DATA_EXPLORER_CATEGORY_KEY.POPULATION_ABBREVIATION]: false,
             [HPRC_DATA_EXPLORER_CATEGORY_KEY.POPULATION_DESCRIPTOR]: false,
             [HPRC_DATA_EXPLORER_CATEGORY_KEY.PROJECT]: false,
             [HPRC_DATA_EXPLORER_CATEGORY_KEY.STUDY]: false,
-            [HPRC_DATA_EXPLORER_CATEGORY_KEY.TOTAL_GBP]: false,
             [HPRC_DATA_EXPLORER_CATEGORY_KEY.TOTAL_READS]: false,
             [HPRC_DATA_EXPLORER_CATEGORY_KEY.WHALES]: false,
           },

--- a/site-config/hprc-data-explorer/local/index/rawSequencingDataEntityConfig.ts
+++ b/site-config/hprc-data-explorer/local/index/rawSequencingDataEntityConfig.ts
@@ -481,6 +481,7 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
             HPRCDataExplorerRawSequencingData
           >,
           enableGrouping: true,
+          filterFn: "inNumberRange",
           header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.COVERAGE,
           id: HPRC_DATA_EXPLORER_CATEGORY_KEY.COVERAGE,
           width: { max: "0.5fr", min: "112px" },
@@ -494,6 +495,7 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
             HPRCDataExplorerRawSequencingData
           >,
           enableGrouping: true,
+          filterFn: "inNumberRange",
           header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.TOTAL_GBP,
           id: HPRC_DATA_EXPLORER_CATEGORY_KEY.TOTAL_GBP,
           width: { max: "0.5fr", min: "144px" },
@@ -507,6 +509,7 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
             HPRCDataExplorerRawSequencingData
           >,
           enableGrouping: true,
+          filterFn: "inNumberRange",
           header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.N50,
           id: HPRC_DATA_EXPLORER_CATEGORY_KEY.N50,
           width: { max: "0.5fr", min: "112px" },
@@ -520,6 +523,7 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
             HPRCDataExplorerRawSequencingData
           >,
           enableGrouping: true,
+          filterFn: "inNumberRange",
           header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.TOTAL_READS,
           id: HPRC_DATA_EXPLORER_CATEGORY_KEY.TOTAL_READS,
           width: { max: "0.5fr", min: "112px" },
@@ -533,6 +537,7 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
             HPRCDataExplorerRawSequencingData
           >,
           enableGrouping: true,
+          filterFn: "inNumberRange",
           header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.ONE_HUNDRED_KB_PLUS,
           id: HPRC_DATA_EXPLORER_CATEGORY_KEY.ONE_HUNDRED_KB_PLUS,
           width: { max: "0.5fr", min: "112px" },
@@ -546,6 +551,7 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
             HPRCDataExplorerRawSequencingData
           >,
           enableGrouping: true,
+          filterFn: "inNumberRange",
           header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.WHALES,
           id: HPRC_DATA_EXPLORER_CATEGORY_KEY.WHALES,
           width: { max: "0.5fr", min: "112px" },


### PR DESCRIPTION
## Summary
- Reorganizes Sequencing Data filters into **Source**, **Sample**, **Sequencing**, and **Metrics** groups
- Adds new filters: Generator Facility, Population Descriptor/Abbreviation, Family ID, Library Source, Basecaller Model, CCS Algorithm
- Adds **Metrics** range filter group (Coverage, Total Gbp, N50, Total Reads, 100kb+, Whales) using `VIEW_KIND.RANGE`
- Adds **Coverage** as a new visible-by-default column
- Renames "Accession" label to "Run Accession"
- Reorders all 31 columns per spec: identifiers → sample → source → sequencing → metrics → extras
- Updates default visibility: 11 visible, 20 hidden

Depends on #250 (base branch)

Closes #247

## Test plan
- [x] Verify 11 columns visible by default (Download, Filename, Run Accession, Sample ID, Platform, Instrument Model, Library Strategy, Filetype, Coverage, Total Gbp, N50)
- [x] Verify 20 columns hidden but accessible via column chooser
- [x] Verify Source/Sample/Sequencing/Metrics filter groups render correctly
- [x] Verify Metrics range filters work (slider UI)
- [x] Verify "Run Accession" label appears instead of "Accession"
- [x] Verify Coverage column displays values correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2074" height="1159" alt="image" src="https://github.com/user-attachments/assets/9ee20dd6-5655-4da3-8334-df1356ee42ec" />

<img width="2073" height="1190" alt="image" src="https://github.com/user-attachments/assets/81009e39-7326-4767-ac63-3528ec2a489e" />
