### PR TITLE
feat: alignments tab filter grouping and column order (#254)

### DIFF
--- a/site-config/hprc-data-explorer/local/index/alignmentEntityConfig.ts
+++ b/site-config/hprc-data-explorer/local/index/alignmentEntityConfig.ts
@@ -32,22 +32,23 @@ export const alignmentEntityConfig: EntityConfig<HPRCDataExplorerAlignment> = {
             label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.HPRC_VERSION,
           },
           {
-            key: HPRC_DATA_EXPLORER_CATEGORY_KEY.PIPELINE,
-            label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.PIPELINE,
-          },
-          {
             key: HPRC_DATA_EXPLORER_CATEGORY_KEY.REFERENCE_COORDINATES,
             label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.REFERENCE_COORDINATES,
           },
           {
-            key: HPRC_DATA_EXPLORER_CATEGORY_KEY.FILENAME,
-            label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.FILENAME,
+            key: HPRC_DATA_EXPLORER_CATEGORY_KEY.PIPELINE,
+            label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.PIPELINE,
           },
           {
             key: HPRC_DATA_EXPLORER_CATEGORY_KEY.FILETYPE,
             label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.FILETYPE,
           },
+          {
+            key: HPRC_DATA_EXPLORER_CATEGORY_KEY.FILENAME,
+            label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.FILENAME,
+          },
         ],
+        label: "Alignment",
       },
     ],
     key: "alignments",
@@ -88,12 +89,12 @@ export const alignmentEntityConfig: EntityConfig<HPRCDataExplorerAlignment> = {
       {
         componentConfig: {
           component: C.BasicCell,
-          viewBuilder: V.buildFileSize,
+          viewBuilder: V.buildAlignment,
         } as ComponentConfig<typeof C.BasicCell, HPRCDataExplorerAlignment>,
-        enableGrouping: false,
-        header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.FILE_SIZE,
-        id: HPRC_DATA_EXPLORER_CATEGORY_KEY.FILE_SIZE,
-        width: { max: "0.5fr", min: "112px" },
+        enableGrouping: true,
+        header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.ALIGNMENT,
+        id: HPRC_DATA_EXPLORER_CATEGORY_KEY.ALIGNMENT,
+        width: { max: "1fr", min: "112px" },
       },
       {
         componentConfig: {
@@ -108,22 +109,12 @@ export const alignmentEntityConfig: EntityConfig<HPRCDataExplorerAlignment> = {
       {
         componentConfig: {
           component: C.BasicCell,
-          viewBuilder: V.buildAlignment,
+          viewBuilder: V.buildReferenceCoordinates,
         } as ComponentConfig<typeof C.BasicCell, HPRCDataExplorerAlignment>,
         enableGrouping: true,
-        header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.ALIGNMENT,
-        id: HPRC_DATA_EXPLORER_CATEGORY_KEY.ALIGNMENT,
+        header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.REFERENCE_COORDINATES,
+        id: HPRC_DATA_EXPLORER_CATEGORY_KEY.REFERENCE_COORDINATES,
         width: { max: "1fr", min: "112px" },
-      },
-      {
-        componentConfig: {
-          component: C.BasicCell,
-          viewBuilder: V.buildFiletype,
-        } as ComponentConfig<typeof C.BasicCell, HPRCDataExplorerAlignment>,
-        enableGrouping: true,
-        header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.FILETYPE,
-        id: HPRC_DATA_EXPLORER_CATEGORY_KEY.FILETYPE,
-        width: { max: "0.5fr", min: "112px" },
       },
       {
         componentConfig: {
@@ -138,12 +129,22 @@ export const alignmentEntityConfig: EntityConfig<HPRCDataExplorerAlignment> = {
       {
         componentConfig: {
           component: C.BasicCell,
-          viewBuilder: V.buildReferenceCoordinates,
+          viewBuilder: V.buildFiletype,
         } as ComponentConfig<typeof C.BasicCell, HPRCDataExplorerAlignment>,
         enableGrouping: true,
-        header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.REFERENCE_COORDINATES,
-        id: HPRC_DATA_EXPLORER_CATEGORY_KEY.REFERENCE_COORDINATES,
-        width: { max: "1fr", min: "112px" },
+        header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.FILETYPE,
+        id: HPRC_DATA_EXPLORER_CATEGORY_KEY.FILETYPE,
+        width: { max: "0.5fr", min: "112px" },
+      },
+      {
+        componentConfig: {
+          component: C.BasicCell,
+          viewBuilder: V.buildFileSize,
+        } as ComponentConfig<typeof C.BasicCell, HPRCDataExplorerAlignment>,
+        enableGrouping: false,
+        header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.FILE_SIZE,
+        id: HPRC_DATA_EXPLORER_CATEGORY_KEY.FILE_SIZE,
+        width: { max: "0.5fr", min: "112px" },
       },
     ],
     tableOptions: {
@@ -152,10 +153,6 @@ export const alignmentEntityConfig: EntityConfig<HPRCDataExplorerAlignment> = {
       enableGrouping: true,
       enableTableDownload: true,
       initialState: {
-        columnVisibility: {
-          [HPRC_DATA_EXPLORER_CATEGORY_KEY.FILETYPE]: false,
-          [HPRC_DATA_EXPLORER_CATEGORY_KEY.HPRC_VERSION]: false,
-        },
         expanded: true,
         grouping: [HPRC_DATA_EXPLORER_CATEGORY_KEY.ALIGNMENT],
         sorting: [


### PR DESCRIPTION
## Summary
- Reorders filters: Alignment, HPRC Version, Reference Coordinates, Pipeline, Filetype, Filename (broad → specific, filename last as lookup pattern)
- Adds "Alignment" group label to filter group
- Reorders columns to match filter order: Download, Filename (pinned), Alignment, HPRC Version, Reference Coordinates, Pipeline, Filetype, File Size
- Flips Filetype and HPRC Version to visible (removed from `columnVisibility`) — all 8 columns now visible by default
- Preserves existing grouping by Alignment and descending sort

Depends on #262 (base branch: fran/251-assemblies)

Closes #254

## Test plan
- [x] Verify all 8 columns visible by default on Alignments tab (grouped by alignment)
- [x] Verify column order matches: Download, Filename, Alignment, HPRC Version, Reference Coordinates, Pipeline, Filetype, File Size
- [x] Verify filter order: Alignment, HPRC Version, Reference Coordinates, Pipeline, Filetype, Filename
- [x] Verify "Alignment" group label appears above filters
- [x] Verify grouping by Alignment still works
- [x] Verify Filetype and HPRC Version are now visible (previously hidden)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2308" height="1157" alt="image" src="https://github.com/user-attachments/assets/1bb5de5f-bee9-4868-a721-a2cece0b83fe" />
