### PR TITLE
feat: annotations tab filters, column defaults, expose assembly_name (#252)

### DIFF
--- a/app/apis/catalog/hprc-data-explorer/common/entities.ts
+++ b/app/apis/catalog/hprc-data-explorer/common/entities.ts
@@ -90,6 +90,7 @@ export type HPRCDataExplorerAssembly = WithAbsentValues<{
 
 export type HPRCDataExplorerAnnotation = WithAbsentValues<{
   annotationType: string;
+  assemblyName: string;
   biosampleAccession: string;
   contributors: string;
   familyId: string;

--- a/app/viewModelBuilders/catalog/hprc-data-explorer/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hprc-data-explorer/common/viewModelBuilders.ts
@@ -107,14 +107,14 @@ export const buildAssemblyMethodVersion = (
 
 /**
  * Build props for the assembly name cell.
- * @param assembly - Assembly entity.
+ * @param entity - Assembly or annotation entity.
  * @returns Props to be used for the cell.
  */
 export const buildAssemblyName = (
-  assembly: HPRCDataExplorerAssembly
+  entity: HPRCDataExplorerAssembly | HPRCDataExplorerAnnotation
 ): React.ComponentProps<typeof C.BasicCell> => {
   return {
-    value: assembly.assemblyName,
+    value: entity.assemblyName,
   };
 };
 

--- a/catalog/build/ts/build-catalog.ts
+++ b/catalog/build/ts/build-catalog.ts
@@ -264,6 +264,7 @@ async function buildAnnotations(
     );
     return {
       annotationType: parseStringOrAbsent(row.annotation_type),
+      assemblyName: parseStringOrAbsent(row.assembly_name),
       biosampleAccession: sample.biosampleAccession,
       contributors: sample.contributors,
       familyId: sample.familyId,

--- a/site-config/hprc-data-explorer/local/index/annotationEntityConfig.ts
+++ b/site-config/hprc-data-explorer/local/index/annotationEntityConfig.ts
@@ -24,8 +24,29 @@ export const annotationEntityConfig: EntityConfig<HPRCDataExplorerAnnotation> =
         {
           categoryConfigs: [
             {
-              key: HPRC_DATA_EXPLORER_CATEGORY_KEY.RELEASE,
-              label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.RELEASE,
+              key: HPRC_DATA_EXPLORER_CATEGORY_KEY.PROJECT,
+              label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.PROJECT,
+            },
+            {
+              key: HPRC_DATA_EXPLORER_CATEGORY_KEY.CONTRIBUTORS,
+              label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.CONTRIBUTORS,
+            },
+          ],
+          label: "Source",
+        },
+        {
+          categoryConfigs: [
+            {
+              key: HPRC_DATA_EXPLORER_CATEGORY_KEY.POPULATION_DESCRIPTOR,
+              label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.POPULATION_DESCRIPTOR,
+            },
+            {
+              key: HPRC_DATA_EXPLORER_CATEGORY_KEY.POPULATION_ABBREVIATION,
+              label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.POPULATION_ABBREVIATION,
+            },
+            {
+              key: HPRC_DATA_EXPLORER_CATEGORY_KEY.FAMILY_ID,
+              label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.FAMILY_ID,
             },
             {
               key: HPRC_DATA_EXPLORER_CATEGORY_KEY.SAMPLE_ID,
@@ -35,23 +56,25 @@ export const annotationEntityConfig: EntityConfig<HPRCDataExplorerAnnotation> =
               key: HPRC_DATA_EXPLORER_CATEGORY_KEY.BIOSAMPLE_ACCESSION,
               label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.BIOSAMPLE_ACCESSION,
             },
+          ],
+          label: "Sample",
+        },
+        {
+          categoryConfigs: [
             {
-              key: HPRC_DATA_EXPLORER_CATEGORY_KEY.HAPLOTYPE,
-              label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.HAPLOTYPE,
+              key: HPRC_DATA_EXPLORER_CATEGORY_KEY.RELEASE,
+              label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.RELEASE,
             },
             {
               key: HPRC_DATA_EXPLORER_CATEGORY_KEY.ANNOTATION_TYPE,
               label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.ANNOTATION_TYPE,
             },
             {
-              key: HPRC_DATA_EXPLORER_CATEGORY_KEY.PROJECT,
-              label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.PROJECT,
-            },
-            {
-              key: HPRC_DATA_EXPLORER_CATEGORY_KEY.CONTRIBUTORS,
-              label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.CONTRIBUTORS,
+              key: HPRC_DATA_EXPLORER_CATEGORY_KEY.HAPLOTYPE,
+              label: HPRC_DATA_EXPLORER_CATEGORY_LABEL.HAPLOTYPE,
             },
           ],
+          label: "Annotation",
         },
       ],
       key: "annotations",
@@ -105,55 +128,12 @@ export const annotationEntityConfig: EntityConfig<HPRCDataExplorerAnnotation> =
         {
           componentConfig: {
             component: C.BasicCell,
-            viewBuilder: V.buildFileSize,
+            viewBuilder: V.buildAssemblyName,
           } as ComponentConfig<typeof C.BasicCell, HPRCDataExplorerAnnotation>,
           enableGrouping: false,
-          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.FILE_SIZE,
-          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.FILE_SIZE,
-          width: { max: "0.5fr", min: "112px" },
-        },
-        {
-          componentConfig: {
-            component: C.BasicCell,
-            viewBuilder: V.buildRelease,
-          } as ComponentConfig<typeof C.BasicCell, HPRCDataExplorerAnnotation>,
-          enableGrouping: true,
-          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.RELEASE,
-          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.RELEASE,
-          width: { max: "0.5fr", min: "80px" },
-        },
-        {
-          componentConfig: {
-            component: C.BasicCell,
-            viewBuilder: V.buildHaplotype,
-          } as ComponentConfig<typeof C.BasicCell, HPRCDataExplorerAnnotation>,
-          enableGrouping: true,
-          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.HAPLOTYPE,
-          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.HAPLOTYPE,
-          width: { max: "0.5fr", min: "112px" },
-        },
-        {
-          componentConfig: {
-            component: C.BasicCell,
-            viewBuilder: V.buildAnnotationType,
-          } as ComponentConfig<typeof C.BasicCell, HPRCDataExplorerAnnotation>,
-          enableGrouping: true,
-          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.ANNOTATION_TYPE,
-          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.ANNOTATION_TYPE,
-          width: { max: "1fr", min: "160px" },
-        },
-        {
-          componentConfig: {
-            component: C.TypographyNoWrap,
-            viewBuilder: V.buildFileLocation,
-          } as ComponentConfig<
-            typeof C.TypographyNoWrap,
-            HPRCDataExplorerAnnotation
-          >,
-          enableGrouping: true,
-          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.FILE_LOCATION,
-          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.FILE_LOCATION,
-          width: { max: "1fr", min: "112px" },
+          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.ASSEMBLY_NAME,
+          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.ASSEMBLY_NAME,
+          width: { max: "0.5fr", min: "160px" },
         },
         {
           componentConfig: {
@@ -168,12 +148,12 @@ export const annotationEntityConfig: EntityConfig<HPRCDataExplorerAnnotation> =
         {
           componentConfig: {
             component: C.BasicCell,
-            viewBuilder: V.buildFamilyId,
+            viewBuilder: V.buildPopulationDescriptor,
           } as ComponentConfig<typeof C.BasicCell, HPRCDataExplorerAnnotation>,
           enableGrouping: true,
-          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.FAMILY_ID,
-          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.FAMILY_ID,
-          width: { max: "0.5fr", min: "112px" },
+          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.POPULATION_DESCRIPTOR,
+          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.POPULATION_DESCRIPTOR,
+          width: { max: "1fr", min: "160px" },
         },
         {
           componentConfig: {
@@ -188,12 +168,12 @@ export const annotationEntityConfig: EntityConfig<HPRCDataExplorerAnnotation> =
         {
           componentConfig: {
             component: C.BasicCell,
-            viewBuilder: V.buildPopulationDescriptor,
+            viewBuilder: V.buildFamilyId,
           } as ComponentConfig<typeof C.BasicCell, HPRCDataExplorerAnnotation>,
           enableGrouping: true,
-          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.POPULATION_DESCRIPTOR,
-          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.POPULATION_DESCRIPTOR,
-          width: { max: "1fr", min: "160px" },
+          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.FAMILY_ID,
+          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.FAMILY_ID,
+          width: { max: "0.5fr", min: "112px" },
         },
         {
           componentConfig: {
@@ -215,6 +195,59 @@ export const annotationEntityConfig: EntityConfig<HPRCDataExplorerAnnotation> =
           id: HPRC_DATA_EXPLORER_CATEGORY_KEY.CONTRIBUTORS,
           width: { max: "1fr", min: "160px" },
         },
+        {
+          componentConfig: {
+            component: C.BasicCell,
+            viewBuilder: V.buildRelease,
+          } as ComponentConfig<typeof C.BasicCell, HPRCDataExplorerAnnotation>,
+          enableGrouping: true,
+          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.RELEASE,
+          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.RELEASE,
+          width: { max: "0.5fr", min: "80px" },
+        },
+        {
+          componentConfig: {
+            component: C.BasicCell,
+            viewBuilder: V.buildAnnotationType,
+          } as ComponentConfig<typeof C.BasicCell, HPRCDataExplorerAnnotation>,
+          enableGrouping: true,
+          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.ANNOTATION_TYPE,
+          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.ANNOTATION_TYPE,
+          width: { max: "1fr", min: "160px" },
+        },
+        {
+          componentConfig: {
+            component: C.BasicCell,
+            viewBuilder: V.buildHaplotype,
+          } as ComponentConfig<typeof C.BasicCell, HPRCDataExplorerAnnotation>,
+          enableGrouping: true,
+          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.HAPLOTYPE,
+          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.HAPLOTYPE,
+          width: { max: "0.5fr", min: "112px" },
+        },
+        {
+          componentConfig: {
+            component: C.BasicCell,
+            viewBuilder: V.buildFileSize,
+          } as ComponentConfig<typeof C.BasicCell, HPRCDataExplorerAnnotation>,
+          enableGrouping: false,
+          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.FILE_SIZE,
+          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.FILE_SIZE,
+          width: { max: "0.5fr", min: "112px" },
+        },
+        {
+          componentConfig: {
+            component: C.TypographyNoWrap,
+            viewBuilder: V.buildFileLocation,
+          } as ComponentConfig<
+            typeof C.TypographyNoWrap,
+            HPRCDataExplorerAnnotation
+          >,
+          enableGrouping: false,
+          header: HPRC_DATA_EXPLORER_CATEGORY_LABEL.FILE_LOCATION,
+          id: HPRC_DATA_EXPLORER_CATEGORY_KEY.FILE_LOCATION,
+          width: { max: "1fr", min: "112px" },
+        },
       ],
       tableOptions: {
         downloadFilename: "annotations",
@@ -223,11 +256,10 @@ export const annotationEntityConfig: EntityConfig<HPRCDataExplorerAnnotation> =
         enableTableDownload: true,
         initialState: {
           columnVisibility: {
-            [HPRC_DATA_EXPLORER_CATEGORY_KEY.CONTRIBUTORS]: false,
+            [HPRC_DATA_EXPLORER_CATEGORY_KEY.ASSEMBLY_NAME]: false,
             [HPRC_DATA_EXPLORER_CATEGORY_KEY.FAMILY_ID]: false,
+            [HPRC_DATA_EXPLORER_CATEGORY_KEY.FILE_LOCATION]: false,
             [HPRC_DATA_EXPLORER_CATEGORY_KEY.POPULATION_ABBREVIATION]: false,
-            [HPRC_DATA_EXPLORER_CATEGORY_KEY.POPULATION_DESCRIPTOR]: false,
-            [HPRC_DATA_EXPLORER_CATEGORY_KEY.PROJECT]: false,
           },
           expanded: true,
           sorting: [


### PR DESCRIPTION
## Summary
- Exposes `assembly_name` from the annotations CSV as a new column (hidden by default)
- Adds `assemblyName` to `HPRCDataExplorerAnnotation` entity type and catalog build transform
- Widens `buildAssemblyName` view builder to accept both Assembly and Annotation entities
- Reorganizes filters into **Source** (Project, Contributors), **Sample** (Population Descriptor, Population Abbreviation, Family ID, Sample ID, Biosample Accession), and **Annotation** (Release, Annotation Type, Haplotype) groups
- Reorders all 15 columns per spec
- Updates default visibility: 11 visible, 4 hidden (Assembly Name, Family ID, File Location, Population Abbreviation)
- Rebuilds catalog output JSON with assemblyName field

Depends on #263 (base branch: fran/254-alignments)
Closes #252

## Test plan
- [x] Verify 11 columns visible by default on Annotations tab
- [x] Verify 4 hidden columns accessible via column chooser
- [x] Verify Source/Sample/Annotation filter groups render correctly
- [x] Verify new Sample-group filters work
- [x] Verify Assembly Name column shows values for Release 2 records

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2313" height="1088" alt="image" src="https://github.com/user-attachments/assets/0fb92da2-acba-4336-8c2f-cc0b1d37543d" />

<img width="2315" height="1019" alt="image" src="https://github.com/user-attachments/assets/e0c572fe-f564-47c5-b9ac-e9d0bd32884e" />

<img width="2312" height="1074" alt="image" src="https://github.com/user-attachments/assets/40a66928-98e7-4918-b32a-39b5b4c8c0a0" />

<img width="2315" height="1116" alt="image" src="https://github.com/user-attachments/assets/d73a104e-bbec-41a8-90c9-0bdb96a129fa" />

