### PR TITLE
feat: surface per-entity help link on entity pages (#264)

### DIFF
--- a/app/views/ExploreView/components/EntityTitle/entityTitle.styles.ts
+++ b/app/views/ExploreView/components/EntityTitle/entityTitle.styles.ts
@@ -1,0 +1,23 @@
+import { FONT } from "@databiosphere/findable-ui/lib/styles/common/constants/font";
+import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
+import styled from "@emotion/styled";
+import { Stack } from "@mui/material";
+
+export const StyledStack = styled(Stack)`
+  align-items: center;
+  flex-direction: row;
+  gap: 16px;
+
+  .MuiTypography-root {
+    letter-spacing: normal;
+  }
+
+  .MuiLink-root {
+    align-items: center;
+    color: ${PALETTE.INK_LIGHT};
+    display: flex;
+    font: ${FONT.BODY_SMALL_400};
+    gap: 2px;
+    padding: 4px 0;
+  }
+`;

--- a/app/views/ExploreView/components/EntityTitle/entityTitle.tsx
+++ b/app/views/ExploreView/components/EntityTitle/entityTitle.tsx
@@ -1,0 +1,35 @@
+import type { JSX } from "react";
+
+import {
+  ANCHOR_TARGET,
+  REL_ATTRIBUTE,
+} from "@databiosphere/findable-ui/lib/components/Links/common/entities";
+import { LINK_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/link";
+import { SVG_ICON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/svgIcon";
+import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+import { ArrowForwardRounded } from "@mui/icons-material";
+import { Link, Typography } from "@mui/material";
+import { StyledStack } from "./entityTitle.styles";
+import { Props } from "./types";
+
+export const EntityTitle = ({ slotProps, title }: Props): JSX.Element => {
+  const { link: linkProps } = slotProps || {};
+  return (
+    <StyledStack>
+      <Typography component="h1" variant={TYPOGRAPHY_PROPS.VARIANT.HEADING}>
+        {title}
+      </Typography>
+      {linkProps && (
+        <Link
+          rel={REL_ATTRIBUTE.NO_OPENER_NO_REFERRER}
+          target={ANCHOR_TARGET.BLANK}
+          underline={LINK_PROPS.UNDERLINE.NONE}
+          {...linkProps}
+        >
+          {`About ${title}`}
+          <ArrowForwardRounded fontSize={SVG_ICON_PROPS.FONT_SIZE.XXSMALL} />
+        </Link>
+      )}
+    </StyledStack>
+  );
+};

--- a/app/views/ExploreView/components/EntityTitle/types.ts
+++ b/app/views/ExploreView/components/EntityTitle/types.ts
@@ -1,0 +1,8 @@
+import { LinkProps } from "@mui/material";
+
+export interface Props {
+  slotProps?: {
+    link?: LinkProps;
+  };
+  title: string;
+}

--- a/e2e/testFunctions.ts
+++ b/e2e/testFunctions.ts
@@ -132,7 +132,9 @@ export async function testFilterPresence(
 ): Promise<void> {
   // Goto the selected tab
   await page.goto(tab.url);
-  await expect(page.getByRole("link").getByText(tab.tabName)).toBeVisible();
+  await expect(
+    page.getByTestId("navigation").getByRole("link", { name: tab.tabName })
+  ).toBeVisible();
   for (const filterName of filterNames) {
     // Check that each filter is visible and clickable
     await expect(page.getByText(filterRegex(filterName))).toBeVisible();

--- a/site-config/hprc-data-explorer/docs.ts
+++ b/site-config/hprc-data-explorer/docs.ts
@@ -1,0 +1,10 @@
+export const DOCUMENTATION_URL = {
+  ANNOTATIONS:
+    "https://github.com/human-pangenomics/hprc_intermediate_assembly/blob/main/data_tables/annotation/README.md",
+  ASSEMBLIES:
+    "https://github.com/human-pangenomics/hprc_intermediate_assembly/blob/main/data_tables/README.md",
+  SAMPLES:
+    "https://github.com/human-pangenomics/hprc_intermediate_assembly/blob/main/data_tables/sample/README.md",
+  SEQUENCING_DATA:
+    "https://github.com/human-pangenomics/hprc_intermediate_assembly/blob/main/data_tables/sequencing_data/README.md",
+};

--- a/site-config/hprc-data-explorer/local/config.ts
+++ b/site-config/hprc-data-explorer/local/config.ts
@@ -3,6 +3,7 @@ import { ANCHOR_TARGET } from "@databiosphere/findable-ui/lib/components/Links/c
 import { SiteConfig } from "@databiosphere/findable-ui/lib/config/entities";
 import * as C from "../../../app/components/index";
 import { ROUTE } from "../../../app/routes/constants";
+import { DOCUMENTATION_URL } from "../docs";
 import { alignmentEntityConfig } from "./index/alignmentEntityConfig";
 import { annotationEntityConfig } from "./index/annotationEntityConfig";
 import { assemblyEntityConfig } from "./index/assemblyEntityConfig";
@@ -89,22 +90,22 @@ export function makeConfig(browserUrl: string, gitHubUrl: string): SiteConfig {
                 {
                   label: "Samples",
                   target: ANCHOR_TARGET.BLANK,
-                  url: "https://github.com/human-pangenomics/hprc_intermediate_assembly/blob/main/data_tables/sample/README.md",
+                  url: DOCUMENTATION_URL.SAMPLES,
                 },
                 {
                   label: "Assemblies",
                   target: ANCHOR_TARGET.BLANK,
-                  url: "https://github.com/human-pangenomics/hprc_intermediate_assembly/blob/main/data_tables/README.md",
+                  url: DOCUMENTATION_URL.ASSEMBLIES,
                 },
                 {
                   label: "Sequencing Data",
                   target: ANCHOR_TARGET.BLANK,
-                  url: "https://github.com/human-pangenomics/hprc_intermediate_assembly/blob/main/data_tables/sequencing_data/README.md",
+                  url: DOCUMENTATION_URL.SEQUENCING_DATA,
                 },
                 {
                   label: "Annotations",
                   target: ANCHOR_TARGET.BLANK,
-                  url: "https://github.com/human-pangenomics/hprc_intermediate_assembly/blob/main/data_tables/annotation/README.md",
+                  url: DOCUMENTATION_URL.ANNOTATIONS,
                 },
                 {
                   icon: C.GitHubIcon({ fontSize: "small" }),

--- a/site-config/hprc-data-explorer/local/index/alignmentEntityConfig.ts
+++ b/site-config/hprc-data-explorer/local/index/alignmentEntityConfig.ts
@@ -9,6 +9,7 @@ import { HPRCDataExplorerAlignment } from "../../../../app/apis/catalog/hprc-dat
 import { getAlignmentId } from "../../../../app/apis/catalog/hprc-data-explorer/common/utils";
 import * as C from "../../../../app/components/index";
 import * as V from "../../../../app/viewModelBuilders/catalog/hprc-data-explorer/common/viewModelBuilders";
+import { EntityTitle } from "../../../../app/views/ExploreView/components/EntityTitle/entityTitle";
 import {
   HPRC_DATA_EXPLORER_CATEGORY_KEY,
   HPRC_DATA_EXPLORER_CATEGORY_LABEL,
@@ -169,5 +170,8 @@ export const alignmentEntityConfig: EntityConfig<HPRCDataExplorerAlignment> = {
   },
   route: "alignments",
   staticLoadFile: "catalog/output/alignments.json",
-  ui: { slots: { entityListSlot }, title: "Alignments" },
+  ui: {
+    slots: { entityListSlot },
+    title: EntityTitle({ title: "Alignments" }),
+  },
 };

--- a/site-config/hprc-data-explorer/local/index/annotationEntityConfig.ts
+++ b/site-config/hprc-data-explorer/local/index/annotationEntityConfig.ts
@@ -9,10 +9,12 @@ import { HPRCDataExplorerAnnotation } from "../../../../app/apis/catalog/hprc-da
 import { getAnnotationId } from "../../../../app/apis/catalog/hprc-data-explorer/common/utils";
 import * as C from "../../../../app/components/index";
 import * as V from "../../../../app/viewModelBuilders/catalog/hprc-data-explorer/common/viewModelBuilders";
+import { EntityTitle } from "../../../../app/views/ExploreView/components/EntityTitle/entityTitle";
 import {
   HPRC_DATA_EXPLORER_CATEGORY_KEY,
   HPRC_DATA_EXPLORER_CATEGORY_LABEL,
 } from "../../category";
+import { DOCUMENTATION_URL } from "../../docs";
 
 /**
  * Entity config object responsible to config anything related to the /annotations route.
@@ -276,5 +278,10 @@ export const annotationEntityConfig: EntityConfig<HPRCDataExplorerAnnotation> =
     },
     route: "annotations",
     staticLoadFile: "catalog/output/annotations.json",
-    ui: { title: "Annotations" },
+    ui: {
+      title: EntityTitle({
+        slotProps: { link: { href: DOCUMENTATION_URL.ANNOTATIONS } },
+        title: "Annotations",
+      }),
+    },
   };

--- a/site-config/hprc-data-explorer/local/index/assemblyEntityConfig.ts
+++ b/site-config/hprc-data-explorer/local/index/assemblyEntityConfig.ts
@@ -9,10 +9,12 @@ import { HPRCDataExplorerAssembly } from "../../../../app/apis/catalog/hprc-data
 import { getAssemblyId } from "../../../../app/apis/catalog/hprc-data-explorer/common/utils";
 import * as C from "../../../../app/components/index";
 import * as V from "../../../../app/viewModelBuilders/catalog/hprc-data-explorer/common/viewModelBuilders";
+import { EntityTitle } from "../../../../app/views/ExploreView/components/EntityTitle/entityTitle";
 import {
   HPRC_DATA_EXPLORER_CATEGORY_KEY,
   HPRC_DATA_EXPLORER_CATEGORY_LABEL,
 } from "../../category";
+import { DOCUMENTATION_URL } from "../../docs";
 
 /**
  * Entity config object responsible to config anything related to the /assemblies route.
@@ -385,5 +387,10 @@ export const assemblyEntityConfig: EntityConfig<HPRCDataExplorerAssembly> = {
   },
   route: "assemblies",
   staticLoadFile: "catalog/output/assemblies.json",
-  ui: { title: "Assemblies" },
+  ui: {
+    title: EntityTitle({
+      slotProps: { link: { href: DOCUMENTATION_URL.ASSEMBLIES } },
+      title: "Assemblies",
+    }),
+  },
 };

--- a/site-config/hprc-data-explorer/local/index/rawSequencingDataEntityConfig.ts
+++ b/site-config/hprc-data-explorer/local/index/rawSequencingDataEntityConfig.ts
@@ -10,10 +10,12 @@ import { HPRCDataExplorerRawSequencingData } from "../../../../app/apis/catalog/
 import { getRawSequencingDataId } from "../../../../app/apis/catalog/hprc-data-explorer/common/utils";
 import * as C from "../../../../app/components/index";
 import * as V from "../../../../app/viewModelBuilders/catalog/hprc-data-explorer/common/viewModelBuilders";
+import { EntityTitle } from "../../../../app/views/ExploreView/components/EntityTitle/entityTitle";
 import {
   HPRC_DATA_EXPLORER_CATEGORY_KEY,
   HPRC_DATA_EXPLORER_CATEGORY_LABEL,
 } from "../../category";
+import { DOCUMENTATION_URL } from "../../docs";
 
 /**
  * Entity config object responsible to config anything related to the /raw-sequencing-data route.
@@ -613,5 +615,10 @@ export const rawSequencingDataEntityConfig: EntityConfig<HPRCDataExplorerRawSequ
     },
     route: "raw-sequencing-data",
     staticLoadFile: "catalog/output/sequencing-data.json",
-    ui: { title: "Sequencing Data" },
+    ui: {
+      title: EntityTitle({
+        slotProps: { link: { href: DOCUMENTATION_URL.SEQUENCING_DATA } },
+        title: "Sequencing Data",
+      }),
+    },
   };

--- a/site-config/hprc-data-explorer/local/index/sampleEntityConfig.ts
+++ b/site-config/hprc-data-explorer/local/index/sampleEntityConfig.ts
@@ -9,10 +9,12 @@ import { HPRCDataExplorerSample } from "../../../../app/apis/catalog/hprc-data-e
 import { getSampleId } from "../../../../app/apis/catalog/hprc-data-explorer/common/utils";
 import * as C from "../../../../app/components/index";
 import * as V from "../../../../app/viewModelBuilders/catalog/hprc-data-explorer/common/viewModelBuilders";
+import { EntityTitle } from "../../../../app/views/ExploreView/components/EntityTitle/entityTitle";
 import {
   HPRC_DATA_EXPLORER_CATEGORY_KEY,
   HPRC_DATA_EXPLORER_CATEGORY_LABEL,
 } from "../../category";
+import { DOCUMENTATION_URL } from "../../docs";
 
 /**
  * Entity config object responsible to config anything related to the /samples route.
@@ -259,5 +261,10 @@ export const sampleEntityConfig: EntityConfig<HPRCDataExplorerSample> = {
   },
   route: "samples",
   staticLoadFile: "catalog/output/samples.json",
-  ui: { title: "Samples" },
+  ui: {
+    title: EntityTitle({
+      slotProps: { link: { href: DOCUMENTATION_URL.SAMPLES } },
+      title: "Samples",
+    }),
+  },
 };


### PR DESCRIPTION
## Summary
- Adds an inline "About {Entity} →" help link next to each entity page title, linking to the corresponding documentation
- Creates `EntityTitle` component at `app/views/ExploreView/components/EntityTitle/` with `slotProps.link` typed as MUI `LinkProps`
- Extracts doc URLs into shared `DOCUMENTATION_URL` constants, used by both the entity titles and the Help & Documentation dropdown
- Applied to all 5 tabs: Samples, Sequencing Data, Assemblies, Annotations (with doc links), and Alignments (title only, no doc link available)

Closes #264

## Test plan
- [x] Verify "About Samples →" link appears next to title on Samples tab, opens correct doc in new tab
- [x] Verify "About Sequencing Data →" link on Sequencing Data tab
- [x] Verify "About Assemblies →" link on Assemblies tab
- [x] Verify "About Annotations →" link on Annotations tab
- [x] Verify Alignments tab renders title without a help link (no doc URL)
- [x] Verify link does not increase header height
- [x] Verify H1 heading size is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1488" height="1058" alt="image" src="https://github.com/user-attachments/assets/526947fd-3de9-409e-8767-b7051e51176d" />

<img width="1487" height="983" alt="image" src="https://github.com/user-attachments/assets/8d1a7e8f-1388-467c-9c94-e83c31ddb77a" />

