### PR TITLE
fix: move exploresteprovider inside errorboundary to prevent crash loops (#270)

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -51,29 +51,29 @@ function MyApp({ Component, pageProps }: AppPropsWithComponent): JSX.Element {
             <LayoutDimensionsProvider>
               <AppLayout>
                 <DXHeader {...header} />
-                <ExploreStateProvider entityListType={entityListType}>
-                  <Main>
-                    <ErrorBoundary
-                      fallbackRender={({
-                        error,
-                        reset,
-                      }: {
-                        error: DataExplorerError;
-                        reset: () => void;
-                      }): JSX.Element => (
-                        <Error
-                          errorMessage={error.message}
-                          requestUrlMessage={error.requestUrlMessage}
-                          rootPath={redirectRootToPath}
-                          onReset={reset}
-                        />
-                      )}
-                    >
+                <Main>
+                  <ErrorBoundary
+                    fallbackRender={({
+                      error,
+                      reset,
+                    }: {
+                      error: DataExplorerError;
+                      reset: () => void;
+                    }): JSX.Element => (
+                      <Error
+                        errorMessage={error.message}
+                        requestUrlMessage={error.requestUrlMessage}
+                        rootPath={redirectRootToPath}
+                        onReset={reset}
+                      />
+                    )}
+                  >
+                    <ExploreStateProvider entityListType={entityListType}>
                       <Component {...pageProps} />
                       <Floating {...floating} />
-                    </ErrorBoundary>
-                  </Main>
-                </ExploreStateProvider>
+                    </ExploreStateProvider>
+                  </ErrorBoundary>
+                </Main>
                 <StyledFooter {...footer} />
               </AppLayout>
             </LayoutDimensionsProvider>


### PR DESCRIPTION
## Summary
- Moves `ExploreStateProvider` inside the `ErrorBoundary` in `pages/_app.tsx` to prevent infinite crash loops when filter query parameters contain invalid values
- Header and Footer remain outside the boundary so users can still navigate away from error pages

Closes #270
Related: DataBiosphere/findable-ui#888

## Test plan
- [x] Verify all entity tabs load and render correctly
- [x] Verify filters work normally
- [x] Verify error page renders when an invalid filter query parameter is used (no infinite loop)
- [x] Verify header and footer remain visible on error pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)