### PR TITLE
feat: default release = 2 filter on first entry to assemblies and annotations (#223)

### DIFF
--- a/app/views/ExploreView/exploreView.tsx
+++ b/app/views/ExploreView/exploreView.tsx
@@ -1,0 +1,25 @@
+import {
+  ExploreView as DXExploreView,
+  ExploreViewProps,
+} from "@databiosphere/findable-ui/lib/views/ExploreView/exploreView";
+import type { JSX } from "react";
+import { useDefaultEntityFilters } from "./hooks/useDefaultEntityFilters/hook";
+
+/**
+ * HPRC-specific wrapper around the findable-ui ExploreView.
+ *
+ * This component applies per-entity default filters on first visit to a tab
+ * within a browser session. For example, the Assemblies and Annotations tabs
+ * default to Release = 2, so users see the latest data without manual filtering.
+ *
+ * The default is applied once per session via sessionStorage and is not reapplied
+ * after the user interacts with filters or navigates between tabs.
+ *
+ * @param props - ExploreView props (entityListType, data, etc.).
+ * @returns ExploreView component with default entity filters applied.
+ */
+export const ExploreView = (props: ExploreViewProps): JSX.Element => {
+  const { entityListType } = props;
+  useDefaultEntityFilters(entityListType);
+  return <DXExploreView {...props} />;
+};

--- a/app/views/ExploreView/hooks/useDefaultEntityFilters/constants.ts
+++ b/app/views/ExploreView/hooks/useDefaultEntityFilters/constants.ts
@@ -1,17 +1,18 @@
 import { HPRC_DATA_EXPLORER_CATEGORY_KEY } from "../../../../../site-config/hprc-data-explorer/category";
 import { DefaultFilter } from "./types";
 
-export const DEFAULT_ENTITY_FILTERS: Record<string, DefaultFilter[]> = {
-  annotations: [
-    {
-      categoryKey: HPRC_DATA_EXPLORER_CATEGORY_KEY.RELEASE,
-      value: "2",
-    },
-  ],
-  assemblies: [
-    {
-      categoryKey: HPRC_DATA_EXPLORER_CATEGORY_KEY.RELEASE,
-      value: "2",
-    },
-  ],
-};
+export const DEFAULT_ENTITY_FILTERS: Partial<Record<string, DefaultFilter[]>> =
+  {
+    annotations: [
+      {
+        categoryKey: HPRC_DATA_EXPLORER_CATEGORY_KEY.RELEASE,
+        value: "2",
+      },
+    ],
+    assemblies: [
+      {
+        categoryKey: HPRC_DATA_EXPLORER_CATEGORY_KEY.RELEASE,
+        value: "2",
+      },
+    ],
+  };

--- a/app/views/ExploreView/hooks/useDefaultEntityFilters/constants.ts
+++ b/app/views/ExploreView/hooks/useDefaultEntityFilters/constants.ts
@@ -1,0 +1,17 @@
+import { HPRC_DATA_EXPLORER_CATEGORY_KEY } from "../../../../../site-config/hprc-data-explorer/category";
+import { DefaultFilter } from "./types";
+
+export const DEFAULT_ENTITY_FILTERS: Record<string, DefaultFilter[]> = {
+  annotations: [
+    {
+      categoryKey: HPRC_DATA_EXPLORER_CATEGORY_KEY.RELEASE,
+      value: "2",
+    },
+  ],
+  assemblies: [
+    {
+      categoryKey: HPRC_DATA_EXPLORER_CATEGORY_KEY.RELEASE,
+      value: "2",
+    },
+  ],
+};

--- a/app/views/ExploreView/hooks/useDefaultEntityFilters/hook.ts
+++ b/app/views/ExploreView/hooks/useDefaultEntityFilters/hook.ts
@@ -1,0 +1,39 @@
+import { useExploreState } from "@databiosphere/findable-ui/lib/hooks/useExploreState";
+import { ExploreActionKind } from "@databiosphere/findable-ui/lib/providers/exploreState";
+import { useEffect } from "react";
+import {
+  getDefaultFilters,
+  hasAppliedDefaults,
+  hasUrlFilterParam,
+  markDefaultsApplied,
+} from "./utils";
+
+/**
+ * Applies default filters on first visit to an entity tab per browser session.
+ * Checks sessionStorage to avoid reapplying after the user has interacted with filters.
+ * Respects explicit URL filter params (direct links).
+ * @param entityListType - Entity list type.
+ */
+export function useDefaultEntityFilters(entityListType: string): void {
+  const { exploreDispatch } = useExploreState();
+
+  useEffect(() => {
+    const defaults = getDefaultFilters(entityListType);
+    if (!defaults) return;
+    if (hasAppliedDefaults(entityListType)) return;
+    if (hasUrlFilterParam()) return;
+
+    for (const { categoryKey, value } of defaults) {
+      exploreDispatch({
+        payload: {
+          categoryKey,
+          selected: true,
+          selectedValue: value,
+        },
+        type: ExploreActionKind.UpdateFilter,
+      });
+    }
+
+    markDefaultsApplied(entityListType);
+  }, [entityListType, exploreDispatch]);
+}

--- a/app/views/ExploreView/hooks/useDefaultEntityFilters/types.ts
+++ b/app/views/ExploreView/hooks/useDefaultEntityFilters/types.ts
@@ -1,0 +1,6 @@
+import { CategoryKey } from "@databiosphere/findable-ui/lib/common/entities";
+
+export interface DefaultFilter {
+  categoryKey: CategoryKey;
+  value: string;
+}

--- a/app/views/ExploreView/hooks/useDefaultEntityFilters/utils.ts
+++ b/app/views/ExploreView/hooks/useDefaultEntityFilters/utils.ts
@@ -1,0 +1,42 @@
+import { DEFAULT_ENTITY_FILTERS } from "./constants";
+import { DefaultFilter } from "./types";
+
+/**
+ * Returns the default filters for the given entity, or undefined if none are configured.
+ * @param entityListType - Entity list type.
+ * @returns default filters, or undefined.
+ */
+export function getDefaultFilters(
+  entityListType: string
+): DefaultFilter[] | undefined {
+  return DEFAULT_ENTITY_FILTERS[entityListType];
+}
+
+/**
+ * Returns true if the default filters have already been applied for the given entity in this session.
+ * @param entityListType - Entity list type.
+ * @returns true if defaults were already applied.
+ */
+export function hasAppliedDefaults(entityListType: string): boolean {
+  return (
+    sessionStorage.getItem(`defaultFiltersApplied_${entityListType}`) !== null
+  );
+}
+
+/**
+ * Returns true if the current URL contains an explicit filter query param.
+ * Uses window.location directly — safe because this is only called inside a
+ * useEffect (always client-side, never during SSR).
+ * @returns true if URL has a filter param.
+ */
+export function hasUrlFilterParam(): boolean {
+  return new URLSearchParams(window.location.search).has("filter");
+}
+
+/**
+ * Marks the default filters as applied for the given entity in this session.
+ * @param entityListType - Entity list type.
+ */
+export function markDefaultsApplied(entityListType: string): void {
+  sessionStorage.setItem(`defaultFiltersApplied_${entityListType}`, "true");
+}

--- a/app/views/ExploreView/hooks/useDefaultEntityFilters/utils.ts
+++ b/app/views/ExploreView/hooks/useDefaultEntityFilters/utils.ts
@@ -14,29 +14,41 @@ export function getDefaultFilters(
 
 /**
  * Returns true if the default filters have already been applied for the given entity in this session.
+ * Treats sessionStorage failures (e.g. disabled storage, Safari private mode) as "not applied".
  * @param entityListType - Entity list type.
  * @returns true if defaults were already applied.
  */
 export function hasAppliedDefaults(entityListType: string): boolean {
-  return (
-    sessionStorage.getItem(`defaultFiltersApplied_${entityListType}`) !== null
-  );
+  try {
+    return (
+      sessionStorage.getItem(`defaultFiltersApplied_${entityListType}`) !== null
+    );
+  } catch {
+    return false;
+  }
 }
 
 /**
  * Returns true if the current URL contains an explicit filter query param.
- * Uses window.location directly — safe because this is only called inside a
- * useEffect (always client-side, never during SSR).
+ * Safely returns false in non-browser environments (e.g. SSR/tests).
  * @returns true if URL has a filter param.
  */
 export function hasUrlFilterParam(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
   return new URLSearchParams(window.location.search).has("filter");
 }
 
 /**
  * Marks the default filters as applied for the given entity in this session.
+ * Silently no-ops if sessionStorage is unavailable.
  * @param entityListType - Entity list type.
  */
 export function markDefaultsApplied(entityListType: string): void {
-  sessionStorage.setItem(`defaultFiltersApplied_${entityListType}`, "true");
+  try {
+    sessionStorage.setItem(`defaultFiltersApplied_${entityListType}`, "true");
+  } catch {
+    // No-op if sessionStorage is unavailable.
+  }
 }

--- a/pages/[entityListType]/index.tsx
+++ b/pages/[entityListType]/index.tsx
@@ -5,12 +5,12 @@ import { getEntityConfig } from "@databiosphere/findable-ui/lib/config/utils";
 import { getEntityService } from "@databiosphere/findable-ui/lib/hooks/useEntityService";
 import { EXPLORE_MODE } from "@databiosphere/findable-ui/lib/hooks/useExploreMode/types";
 import { database } from "@databiosphere/findable-ui/lib/utils/database";
-import { ExploreView } from "@databiosphere/findable-ui/lib/views/ExploreView/exploreView";
 import { config } from "app/config/config";
 import fsp from "fs/promises";
 import { GetStaticPaths, GetStaticProps, GetStaticPropsContext } from "next";
 import { ParsedUrlQuery } from "querystring";
 import type { JSX } from "react";
+import { ExploreView } from "../../app/views/ExploreView/exploreView";
 
 interface PageUrl extends ParsedUrlQuery {
   entityListType: string;


### PR DESCRIPTION
## Summary
- Adds a `useDefaultEntityFilters` hook that applies `Release = 2` filter on first visit to the Assemblies and Annotations tabs
- Uses `sessionStorage` to track per-session, per-entity "already applied" state — default is not reapplied after the user interacts with filters
- Respects explicit URL filter params (direct links are not overridden)
- Creates HPRC-specific `ExploreView` wrapper at `app/views/ExploreView/exploreView.tsx` to keep page files clean
- No findable-ui changes required

### Hook structure
```
app/views/ExploreView/hooks/useDefaultEntityFilters/
  constants.ts  — default filter config per entity
  hook.ts       — the hook (dispatches UpdateFilter on first visit)
  types.ts      — DefaultFilter interface
  utils.ts      — sessionStorage and URL helpers
```

Closes #223

## Test plan
- [x] All 25 e2e tests pass
- [x] First entry to Assemblies defaults to Release = 2
- [x] First entry to Annotations defaults to Release = 2
- [x] Clearing or changing the filter is respected afterward
- [x] Moving between tabs does not forcibly reset filters after initial entry
- [x] Direct link with explicit filter param is not overridden
- [x] New browser session reapplies the default
- [x] Other tabs (Samples, Sequencing Data, Alignments) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2310" height="1076" alt="image" src="https://github.com/user-attachments/assets/65f81789-e575-42a4-9547-966629123cc8" />
